### PR TITLE
spotify 요청 API 작성 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 HELP.md
 .gradle
-**/src/main/resources/application.yml
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 	implementation group: 'jakarta.mail', name: 'jakarta.mail-api', version: '2.1.3'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// Spotify
+	implementation 'se.michaelthelin.spotify:spotify-web-api-java:6.5.2'
+
+
 	// Etc
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/munecting/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/munecting/api/domain/comment/entity/Comment.java
@@ -25,10 +25,12 @@ public class Comment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private Long userId;
 
-    //스포티 파이에서 제공하는 자료형 확인 후 수정 예정
-    private Long musicId;
+    @NotNull
+    private String musicUri;
 
+    @NotNull
     private String content;
 }

--- a/src/main/java/com/munecting/api/domain/like/entity/Like.java
+++ b/src/main/java/com/munecting/api/domain/like/entity/Like.java
@@ -2,6 +2,7 @@ package com.munecting.api.domain.like.entity;
 
 import com.munecting.api.global.common.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,8 +23,9 @@ public class Like extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private Long userId;
 
-    //스포티 파이에서 제공하는 자료형 확인 후 수정 예정
-    private Long musicId;
+    @NotNull
+    private String musicUri;
 }

--- a/src/main/java/com/munecting/api/domain/playList/entity/Playlist.java
+++ b/src/main/java/com/munecting/api/domain/playList/entity/Playlist.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,9 @@ public class Playlist extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private Long userId;
 
+    @NotNull
     private String name;
 }

--- a/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusicId.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusicId.java
@@ -12,20 +12,19 @@ public class PlaylistMusicId implements Serializable {
     @NotNull
     private Long playlistId;
 
-    //스포티 파이에서 제공하는 자료형 확인 후 수정 예정
     @NotNull
-    private Long musicId;
+    private String musicUri;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PlaylistMusicId that = (PlaylistMusicId) o;
-        return Objects.equals(playlistId, that.playlistId) && Objects.equals(musicId, that.musicId);
+        return Objects.equals(playlistId, that.playlistId) && Objects.equals(musicUri, that.musicUri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(playlistId, musicId);
+        return Objects.hash(playlistId, musicUri);
     }
 }

--- a/src/main/java/com/munecting/api/domain/spotify/controller/SpotifyController.java
+++ b/src/main/java/com/munecting/api/domain/spotify/controller/SpotifyController.java
@@ -1,0 +1,91 @@
+package com.munecting.api.domain.spotify.controller;
+
+import com.munecting.api.domain.spotify.dto.AlbumResponseDto;
+import com.munecting.api.domain.spotify.dto.ArtistResponseDto;
+import com.munecting.api.domain.spotify.dto.MusicResponseDto;
+import com.munecting.api.domain.spotify.service.SpotifyService;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/spotify")
+@Tag(name = "spotify", description = "spotify 관련 api")
+public class SpotifyController {
+
+    private final SpotifyService spotifyService;
+
+    @GetMapping("/search/track/{keyword}")
+    @Operation(summary = "키워드로 트랙 검색하기")
+    public ApiResponse<?> searchTracks(
+            @PathVariable("keyword") String keyword,
+            @RequestParam Integer limit,
+            @RequestParam Integer offset
+            ) {
+        List<MusicResponseDto> musicResponseDtoList = spotifyService.searchTracks(keyword, limit, offset);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
+    }
+
+    @GetMapping("/search/album/{keyword}")
+    @Operation(summary = "키워드로 앨범 검색하기")
+    public ApiResponse<?> searchAlbums(
+            @PathVariable("keyword") String keyword,
+            @RequestParam Integer limit,
+            @RequestParam Integer offset
+    ) {
+        List<AlbumResponseDto> albumResponseDtoList = spotifyService.searchAlbums(keyword, limit, offset);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), albumResponseDtoList);
+    }
+
+    @GetMapping("/search/artist/{keyword}")
+    @Operation(summary = "키워드로 아티스트 검색하기")
+    public ApiResponse<?> searchArtists(
+            @PathVariable("keyword") String keyword,
+            @RequestParam Integer limit,
+            @RequestParam Integer offset
+    ) {
+        List<ArtistResponseDto> artistResponseDtoList = spotifyService.searchArtists(keyword, limit, offset);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), artistResponseDtoList);
+    }
+
+    @GetMapping("/album/{id}/tracks")
+    @Operation(summary = "앨범 아이디로 노래 조회하기")
+    public ApiResponse<?> getTracksByAlbumId(
+            @PathVariable("id") String albumId,
+            @RequestParam Integer limit,
+            @RequestParam Integer offset
+    ) {
+        List<MusicResponseDto> musicResponseDtoList = spotifyService.getTracksByAlbumId(albumId, limit, offset);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
+    }
+
+    @GetMapping("/artist/{id}/albums")
+    @Operation(summary = "아티스트 아이디로 앨범 조회하기")
+    public ApiResponse<?> getAlbumsByArtistId(
+            @PathVariable("id") String albumId,
+            @RequestParam Integer limit,
+            @RequestParam Integer offset
+    ) {
+        List<AlbumResponseDto> albumResponseDtoList = spotifyService.getAlbumsByArtistId(albumId, limit, offset);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), albumResponseDtoList);
+    }
+
+    @GetMapping("/track/{id}")
+    @Operation(summary = "노래 아이디로 정보 조회하기")
+    public ApiResponse<?> getAlbumsByArtistId(
+            @PathVariable("id") String trackId
+    ) {
+        MusicResponseDto musicResponseDto = spotifyService.getTrack(trackId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), musicResponseDto);
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/spotify/controller/SpotifyController.java
+++ b/src/main/java/com/munecting/api/domain/spotify/controller/SpotifyController.java
@@ -24,7 +24,7 @@ public class SpotifyController {
 
     private final SpotifyService spotifyService;
 
-    @GetMapping("/search/track/{keyword}")
+    @GetMapping("/search/tracks/{keyword}")
     @Operation(summary = "키워드로 트랙 검색하기")
     public ApiResponse<?> searchTracks(
             @PathVariable("keyword") String keyword,
@@ -35,7 +35,7 @@ public class SpotifyController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
     }
 
-    @GetMapping("/search/album/{keyword}")
+    @GetMapping("/search/albums/{keyword}")
     @Operation(summary = "키워드로 앨범 검색하기")
     public ApiResponse<?> searchAlbums(
             @PathVariable("keyword") String keyword,
@@ -46,7 +46,7 @@ public class SpotifyController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), albumResponseDtoList);
     }
 
-    @GetMapping("/search/artist/{keyword}")
+    @GetMapping("/search/artists/{keyword}")
     @Operation(summary = "키워드로 아티스트 검색하기")
     public ApiResponse<?> searchArtists(
             @PathVariable("keyword") String keyword,
@@ -57,7 +57,7 @@ public class SpotifyController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), artistResponseDtoList);
     }
 
-    @GetMapping("/album/{id}/tracks")
+    @GetMapping("/albums/{id}/tracks")
     @Operation(summary = "앨범 아이디로 노래 조회하기")
     public ApiResponse<?> getTracksByAlbumId(
             @PathVariable("id") String albumId,
@@ -68,7 +68,7 @@ public class SpotifyController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
     }
 
-    @GetMapping("/artist/{id}/albums")
+    @GetMapping("/artists/{id}/albums")
     @Operation(summary = "아티스트 아이디로 앨범 조회하기")
     public ApiResponse<?> getAlbumsByArtistId(
             @PathVariable("id") String albumId,
@@ -79,7 +79,7 @@ public class SpotifyController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.CREATED.getMessage(), albumResponseDtoList);
     }
 
-    @GetMapping("/track/{id}")
+    @GetMapping("/tracks/{id}")
     @Operation(summary = "노래 아이디로 정보 조회하기")
     public ApiResponse<?> getAlbumsByArtistId(
             @PathVariable("id") String trackId

--- a/src/main/java/com/munecting/api/domain/spotify/dto/AlbumResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/spotify/dto/AlbumResponseDto.java
@@ -1,0 +1,21 @@
+package com.munecting.api.domain.spotify.dto;
+
+import com.wrapper.spotify.model_objects.specification.ArtistSimplified;
+import com.wrapper.spotify.model_objects.specification.Image;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class AlbumResponseDto {
+
+    private String albumId;
+    private String albumUri;
+    private String albumTitle;
+    private List<ArtistResponseDto> artists;
+    private Image[] images;
+
+}

--- a/src/main/java/com/munecting/api/domain/spotify/dto/ArtistResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/spotify/dto/ArtistResponseDto.java
@@ -1,0 +1,18 @@
+package com.munecting.api.domain.spotify.dto;
+
+import com.wrapper.spotify.model_objects.specification.Image;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ArtistResponseDto {
+
+    private String artistName;
+    private String artistId;
+    private String artistUri;
+    private Image[] images;
+}

--- a/src/main/java/com/munecting/api/domain/spotify/dto/MusicResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/spotify/dto/MusicResponseDto.java
@@ -1,0 +1,22 @@
+package com.munecting.api.domain.spotify.dto;
+
+import com.wrapper.spotify.model_objects.specification.Artist;
+import com.wrapper.spotify.model_objects.specification.ArtistSimplified;
+import com.wrapper.spotify.model_objects.specification.Image;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class MusicResponseDto {
+
+    private String trackId;
+    private String trackUri;
+    private String trackTitle;
+    private String trackPreview;
+    private List<ArtistResponseDto> artists;
+    private Image[] images;
+}

--- a/src/main/java/com/munecting/api/domain/spotify/dto/SpotifyDtoMapper.java
+++ b/src/main/java/com/munecting/api/domain/spotify/dto/SpotifyDtoMapper.java
@@ -1,0 +1,91 @@
+package com.munecting.api.domain.spotify.dto;
+
+import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
+import com.wrapper.spotify.model_objects.specification.Artist;
+import com.wrapper.spotify.model_objects.specification.Track;
+import com.wrapper.spotify.model_objects.specification.TrackSimplified;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpotifyDtoMapper {
+
+    public MusicResponseDto convertToTrackResponseDto(Track track) {
+        MusicResponseDto responseDto = MusicResponseDto.builder()
+                .trackUri(track.getUri())
+                .trackId(track.getId())
+                .trackTitle(track.getName())
+                .trackPreview(track.getPreviewUrl())
+                .images(track.getAlbum().getImages())
+                .build();
+
+        List<ArtistResponseDto> artistResponseDtos = Stream.of(track.getArtists())
+                .map(artist -> ArtistResponseDto.builder()
+                        .artistId(artist.getId())
+                        .artistUri(artist.getUri())
+                        .artistId(artist.getId())
+                        .artistName(artist.getName())
+                        .build())
+                .collect(Collectors.toList());
+        responseDto.setArtists(artistResponseDtos);
+
+        return responseDto;
+    }
+
+    public MusicResponseDto convertToTrackResponseDto(TrackSimplified trackSimplified) {
+        MusicResponseDto responseDto = MusicResponseDto.builder()
+                .trackUri(trackSimplified.getUri())
+                .trackId(trackSimplified.getId())
+                .trackTitle(trackSimplified.getName())
+                .trackPreview(trackSimplified.getPreviewUrl())
+                .build();
+
+        List<ArtistResponseDto> artistResponseDtos = Stream.of(trackSimplified.getArtists())
+                .map(artist -> ArtistResponseDto.builder()
+                        .artistUri(artist.getUri())
+                        .artistName(artist.getName())
+                        .artistId(artist.getId())
+                        .build())
+                .collect(Collectors.toList());
+        responseDto.setArtists(artistResponseDtos);
+
+        return responseDto;
+    }
+
+    public AlbumResponseDto convertToAlbumResponseDto(AlbumSimplified albumSimplified) {
+        AlbumResponseDto responseDto = AlbumResponseDto.builder()
+                .albumId(albumSimplified.getId())
+                .albumUri(albumSimplified.getUri())
+                .albumTitle(albumSimplified.getName())
+                .images(albumSimplified.getImages())
+                .build();
+
+        List<ArtistResponseDto> artistResponseDtos = Stream.of(albumSimplified.getArtists())
+                .map(artist -> ArtistResponseDto.builder()
+                        .artistUri(artist.getUri())
+                        .artistId(artist.getId())
+                        .artistName(artist.getName())
+                        .build())
+                .collect(Collectors.toList());
+        responseDto.setArtists(artistResponseDtos);
+
+        return responseDto;
+    }
+
+    public ArtistResponseDto convertToArtistResponseDto(Artist artist) {
+
+        ArtistResponseDto artistResponseDto = ArtistResponseDto.builder()
+                .artistId(artist.getId())
+                .artistName(artist.getName())
+                .artistUri(artist.getUri())
+                .images(artist.getImages())
+                .build();
+
+        return artistResponseDto;
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -1,0 +1,163 @@
+package com.munecting.api.domain.spotify.service;
+
+
+import com.munecting.api.domain.spotify.dto.AlbumResponseDto;
+import com.munecting.api.domain.spotify.dto.ArtistResponseDto;
+import com.munecting.api.domain.spotify.dto.MusicResponseDto;
+import com.munecting.api.domain.spotify.dto.SpotifyDtoMapper;
+import com.neovisionaries.i18n.CountryCode;
+import com.wrapper.spotify.SpotifyApi;
+import com.wrapper.spotify.enums.ModelObjectType;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.model_objects.special.SearchResult;
+import com.wrapper.spotify.model_objects.specification.Album;
+import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
+import com.wrapper.spotify.model_objects.specification.Artist;
+import com.wrapper.spotify.model_objects.specification.Paging;
+import com.wrapper.spotify.model_objects.specification.Track;
+import com.wrapper.spotify.model_objects.specification.TrackSimplified;
+import com.wrapper.spotify.requests.data.albums.GetAlbumsTracksRequest;
+import com.wrapper.spotify.requests.data.artists.GetArtistsAlbumsRequest;
+import com.wrapper.spotify.requests.data.search.SearchItemRequest;
+import com.wrapper.spotify.requests.data.tracks.GetTrackRequest;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SpotifyService {
+
+    private final SpotifyApi spotifyApi;
+    private final SpotifyDtoMapper spotifyDtoMapper;
+
+    public List<MusicResponseDto> searchTracks(String keyword, Integer limit, Integer offset) {
+        SearchItemRequest searchItemRequest = spotifyApi.searchItem(keyword, ModelObjectType.TRACK.getType())
+                .limit(limit)
+                .offset(offset)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            final SearchResult searchResult = searchItemRequest.execute();
+            Paging<Track> trackPaging = searchResult.getTracks();
+            Track[] tracks = trackPaging.getItems();
+
+            return Stream.of(tracks)
+                    .map(track -> spotifyDtoMapper.convertToTrackResponseDto(track))
+                    .collect(Collectors.toList());
+
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public List<AlbumResponseDto> searchAlbums(String keyword, Integer limit, Integer offset) {
+        SearchItemRequest searchItemRequest = spotifyApi.searchItem(keyword, ModelObjectType.ALBUM.getType())
+                .limit(limit)
+                .offset(offset)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            final SearchResult searchResult = searchItemRequest.execute();
+
+            Paging<AlbumSimplified> albumPaging = searchResult.getAlbums();
+            AlbumSimplified[] albums = albumPaging.getItems();
+
+            return Stream.of(albums)
+                    .map(album -> spotifyDtoMapper.convertToAlbumResponseDto(album))
+                    .collect(Collectors.toList());
+
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+
+    }
+
+    public List<ArtistResponseDto> searchArtists(String keyword, Integer limit, Integer offset) {
+        SearchItemRequest searchItemRequest = spotifyApi.searchItem(keyword, ModelObjectType.ARTIST.getType())
+                .limit(limit)
+                .offset(offset)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            final SearchResult searchResult = searchItemRequest.execute();
+
+            Paging<Artist> ArtistPaging = searchResult.getArtists();
+            Artist[] artists = ArtistPaging.getItems();
+
+            return Stream.of(artists)
+                    .map(artist -> spotifyDtoMapper.convertToArtistResponseDto(artist))
+                    .collect(Collectors.toList());
+
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+
+    }
+
+    public List<MusicResponseDto> getTracksByAlbumId(String albumId, Integer limit, Integer offset) {
+        GetAlbumsTracksRequest getAlbumsTracksRequest = spotifyApi.getAlbumsTracks(albumId)
+                .limit(limit)
+                .offset(offset)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            Paging<TrackSimplified> trackSimplifiedPaging = getAlbumsTracksRequest.execute();
+            TrackSimplified[] trackSimplifieds = trackSimplifiedPaging.getItems();
+
+            return Stream.of(trackSimplifieds)
+                    .map(trackSimplified -> spotifyDtoMapper.convertToTrackResponseDto(trackSimplified))
+                    .collect(Collectors.toList());
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+
+    }
+
+    public List<AlbumResponseDto> getAlbumsByArtistId(String artistId, Integer limit, Integer offset) {
+        GetArtistsAlbumsRequest getArtistsAlbumsRequest = spotifyApi.getArtistsAlbums(artistId)
+                .limit(limit)
+                .offset(offset)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            Paging<AlbumSimplified> albumSimplifiedPaging = getArtistsAlbumsRequest.execute();
+            AlbumSimplified[] albumSimplifieds = albumSimplifiedPaging.getItems();
+
+            return Stream.of(albumSimplifieds)
+                    .map(albumSimplified -> spotifyDtoMapper.convertToAlbumResponseDto(albumSimplified))
+                    .collect(Collectors.toList());
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+
+    }
+
+    public MusicResponseDto getTrack(String trackId) {
+        GetTrackRequest getTrackRequest = spotifyApi.getTrack(trackId)
+                .market(CountryCode.KR)
+                .build();
+
+        try {
+            Track track = getTrackRequest.execute();
+            return spotifyDtoMapper.convertToTrackResponseDto(track);
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new RuntimeException(ex);
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/com/munecting/api/domain/uploadedMusic/entity/UploadedMusic.java
+++ b/src/main/java/com/munecting/api/domain/uploadedMusic/entity/UploadedMusic.java
@@ -28,9 +28,8 @@ public class UploadedMusic extends BaseEntity {
     @NotNull
     private Long userId;
 
-    //스포티 파이에서 제공하는 자료형 확인 후 수정 예정
     @NotNull
-    private Long musicId;
+    private String musicUri;
 
     @NotNull
     private Double latitude;

--- a/src/main/java/com/munecting/api/global/config/SpotifyConfig.java
+++ b/src/main/java/com/munecting/api/global/config/SpotifyConfig.java
@@ -1,0 +1,48 @@
+package com.munecting.api.global.config;
+
+import com.wrapper.spotify.SpotifyApi;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.model_objects.credentials.ClientCredentials;
+import com.wrapper.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class SpotifyConfig {
+
+    @Value("${spotify.client-id}")
+    private String clientId;
+
+    @Value("${spotify.client-secret}")
+    private String clientSecret;
+
+
+    @Bean
+    public SpotifyApi spotifyApi() {
+        SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                .setClientId(clientId)
+                .setClientSecret(clientSecret)
+                .build();
+        return spotifyApi;
+    }
+
+    @Bean
+    public String spotifyAccessToken(SpotifyApi spotifyApi) {
+        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+        try {
+            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+            spotifyApi.setAccessToken(clientCredentials.getAccessToken());
+            log.info(clientCredentials.getAccessToken());
+            return spotifyApi.getAccessToken();
+        } catch (IOException | SpotifyWebApiException | org.apache.hc.core5.http.ParseException e) {
+            throw new RuntimeException("Error fetching Spotify access token", e);
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+server:
+  port: ${SERVER_PORT}
+
+spring :
+  application:
+    name: munectingV4
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+  jpa:
+    hibernate:
+      ddl-auto: update
+      dialect: org.hibernate.dialect.PostgresSQLDialect
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+  datasource:
+    url: jdbc:${DATASOURCE}://${HOST}:${PORT}/${TABLE}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      initialization-fail-timeout: 3600
+
+  mail:
+    debug: true
+    host: smtp.naver.com
+    port: 465
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            enable: true
+naver:
+  id: ${MAIL_USERNAME}
+  password: ${MAIL_PASSWORD}
+
+spotify:
+  client-id: ${CLIENT_ID}
+  client-secret: ${CLIENT_SECRET}


### PR DESCRIPTION
- spotify에 데이터를 요청해야 하는 부분 개발을 완료했습니다.
- yml 파일 환경변수화 하고 git ignore에서 제외했습니다.

여러가지 API를 작성했는데, 가장 대표적인 것만 보여드리겠습니다.

키워드로 앨범 검색하기 API
![image](https://github.com/user-attachments/assets/a970cc4a-afaa-4269-b3f2-b7bb2cf32684)

앨범 이미지 정보 추출 가능
![image](https://github.com/user-attachments/assets/e6886c18-ed86-48fa-9ded-9fd7a58919f8)

앨범 Id로 노래 검색하기 API
![image](https://github.com/user-attachments/assets/dc9c7e6c-b972-4b46-b422-ff1aaf3a4f8c)

30초 미리 듣기 추출 가능
![image](https://github.com/user-attachments/assets/70944054-338b-40a8-baff-96014d2bf30d)
