### PR TITLE
PlayList 관련 API 작성 완료

### DIFF
--- a/src/main/java/com/munecting/api/MunectingServerApplication.java
+++ b/src/main/java/com/munecting/api/MunectingServerApplication.java
@@ -2,8 +2,10 @@ package com.munecting.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MunectingServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/munecting/api/domain/playList/controller/PlaylistController.java
+++ b/src/main/java/com/munecting/api/domain/playList/controller/PlaylistController.java
@@ -1,0 +1,66 @@
+package com.munecting.api.domain.playList.controller;
+
+import com.munecting.api.domain.playList.dto.PlaylistResponseDto;
+import com.munecting.api.domain.playList.service.PlaylistService;
+import com.munecting.api.domain.spotify.dto.MusicResponseDto;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/playlist")
+@Tag(name = "playlist", description = "playlist 관련 api")
+public class PlaylistController {
+
+    private final PlaylistService playlistService;
+
+    @PostMapping("/")
+    @Operation(summary = "playlist 생성하기")
+    public ApiResponse<?> createPlaylist(
+            @RequestParam String playlistName,
+            @RequestParam Long userId) {
+        Long id = playlistService.createPlaylist(playlistName, userId);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), id);
+    }
+
+    @GetMapping("/all")
+    @Operation(summary = "내 playlist 전체 조회하기")
+    public ApiResponse<?> getMyPlaylist(
+            @RequestParam Long userId,
+            @RequestParam Long cursor,
+            @RequestParam int limit) {
+        List<PlaylistResponseDto> playlistResponseDtoList = playlistService.getMyPlaylist(userId, cursor, limit);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), playlistResponseDtoList);
+    }
+
+    @PatchMapping("/")
+    @Operation(summary = "playlist 이름 수정하기")
+    public ApiResponse<?> modifyPlaylistName(
+            @RequestParam Long playlistId,
+            @RequestParam String playlistName) {
+        Long id = playlistService.modifyPlaylistName(playlistId, playlistName);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
+    }
+
+    @DeleteMapping("/")
+    @Operation(summary = "playlist 삭제하기")
+    public ApiResponse<?> deletePlaylist(
+            @RequestParam Long playlistId) {
+        Long id = playlistService.deletePlaylist(playlistId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
+    }
+
+
+}

--- a/src/main/java/com/munecting/api/domain/playList/controller/PlaylistController.java
+++ b/src/main/java/com/munecting/api/domain/playList/controller/PlaylistController.java
@@ -30,7 +30,7 @@ public class PlaylistController {
     @Operation(summary = "playlist 생성하기")
     public ApiResponse<?> createPlaylist(
             @RequestParam String playlistName,
-            @RequestParam Long userId) {
+            @RequestParam Long userId) { //userId는 추후 인증 과정에서 로그인한 사용자 정보 추출 로직 작성되면 삭제할 예정
         Long id = playlistService.createPlaylist(playlistName, userId);
         return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), id);
     }
@@ -38,7 +38,7 @@ public class PlaylistController {
     @GetMapping("/all")
     @Operation(summary = "내 playlist 전체 조회하기")
     public ApiResponse<?> getMyPlaylist(
-            @RequestParam Long userId,
+            @RequestParam Long userId, //userId는 추후 인증 과정에서 로그인한 사용자 정보 추출 로직 작성되면 삭제할 예정
             @RequestParam Long cursor,
             @RequestParam int limit) {
         List<PlaylistResponseDto> playlistResponseDtoList = playlistService.getMyPlaylist(userId, cursor, limit);

--- a/src/main/java/com/munecting/api/domain/playList/dao/PlaylistRepository.java
+++ b/src/main/java/com/munecting/api/domain/playList/dao/PlaylistRepository.java
@@ -1,0 +1,17 @@
+package com.munecting.api.domain.playList.dao;
+
+import com.munecting.api.domain.playList.entity.Playlist;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+    @Query("SELECT p FROM Playlist p WHERE p.userId = :user_id AND p.id > :id ORDER BY p.id ASC")
+    List<Playlist> findByUserIdAndIdAfter(@Param("user_id") Long userId, @Param("id") Long id, Pageable pageable);
+
+}

--- a/src/main/java/com/munecting/api/domain/playList/dto/PlaylistResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/playList/dto/PlaylistResponseDto.java
@@ -1,0 +1,16 @@
+package com.munecting.api.domain.playList.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class PlaylistResponseDto {
+
+    private Long id;
+
+    private String name;
+
+}

--- a/src/main/java/com/munecting/api/domain/playList/entity/Playlist.java
+++ b/src/main/java/com/munecting/api/domain/playList/entity/Playlist.java
@@ -1,11 +1,16 @@
 package com.munecting.api.domain.playList.entity;
 
+import com.munecting.api.domain.playList.dto.PlaylistResponseDto;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
 import com.munecting.api.global.common.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +20,10 @@ import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(indexes = {@Index(name = "playlist_index", columnList = "userId")})
 public class Playlist extends BaseEntity {
 
     @Id
@@ -30,4 +35,22 @@ public class Playlist extends BaseEntity {
 
     @NotNull
     private String name;
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public static Playlist toEntity(String playlistName, Long userId) {
+        return Playlist.builder()
+                .userId(userId)
+                .name(playlistName)
+                .build();
+    }
+
+    public static PlaylistResponseDto toDto(Playlist playlist) {
+        return PlaylistResponseDto.builder()
+                .id(playlist.id)
+                .name(playlist.name)
+                .build();
+    }
 }

--- a/src/main/java/com/munecting/api/domain/playList/service/PlaylistService.java
+++ b/src/main/java/com/munecting/api/domain/playList/service/PlaylistService.java
@@ -1,0 +1,72 @@
+package com.munecting.api.domain.playList.service;
+
+import com.munecting.api.domain.playList.dao.PlaylistRepository;
+import com.munecting.api.domain.playList.dto.PlaylistResponseDto;
+import com.munecting.api.domain.playList.entity.Playlist;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
+import com.munecting.api.global.common.dto.response.GeneralException;
+import com.munecting.api.global.common.dto.response.Status;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PlaylistService {
+
+    private final PlaylistRepository playlistRepository;
+
+    @Transactional
+    public Long createPlaylist(String playlistName, Long userId) {
+        Playlist playlist = Playlist.toEntity(playlistName, userId);
+        Long id = save(playlist);
+        return id;
+    }
+
+    @Transactional
+    public List<PlaylistResponseDto> getMyPlaylist(Long userId, Long cursor, int limit) {
+        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "id"));
+        List<Playlist> playlists = playlistRepository.findByUserIdAndIdAfter(userId, cursor, pageable);
+        log.info(playlists.size() + " ");
+        return playlists.stream().map(
+                playlist -> Playlist.toDto(playlist))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Long modifyPlaylistName(Long playlistId, String playlistName) {
+        Playlist playlist = findPlaylistById(playlistId);
+        playlist.updateName(playlistName);
+        save(playlist);
+        return playlist.getId();
+    }
+
+    @Transactional
+    public Long deletePlaylist(Long playlistId) {
+        Playlist playlist = findPlaylistById(playlistId);
+        delete(playlist);
+        return playlist.getId();
+    }
+
+    public Long save(Playlist playlist) {
+        return playlistRepository.save(playlist).getId();
+    }
+
+    public void delete(Playlist playlist) {
+        playlistRepository.delete(playlist);
+        // playlistmusic의 delete도 처리
+    }
+
+    public Playlist findPlaylistById(Long id) {
+        return playlistRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(Status.PLAY_LIST_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/playList/service/PlaylistService.java
+++ b/src/main/java/com/munecting/api/domain/playList/service/PlaylistService.java
@@ -26,7 +26,7 @@ public class PlaylistService {
     @Transactional
     public Long createPlaylist(String playlistName, Long userId) {
         Playlist playlist = Playlist.toEntity(playlistName, userId);
-        Long id = save(playlist);
+        Long id = savePlaylistEntity(playlist);
         return id;
     }
 
@@ -44,22 +44,22 @@ public class PlaylistService {
     public Long modifyPlaylistName(Long playlistId, String playlistName) {
         Playlist playlist = findPlaylistById(playlistId);
         playlist.updateName(playlistName);
-        save(playlist);
+        savePlaylistEntity(playlist);
         return playlist.getId();
     }
 
     @Transactional
     public Long deletePlaylist(Long playlistId) {
         Playlist playlist = findPlaylistById(playlistId);
-        delete(playlist);
+        deletePlaylistEntity(playlist);
         return playlist.getId();
     }
 
-    public Long save(Playlist playlist) {
+    public Long savePlaylistEntity(Playlist playlist) {
         return playlistRepository.save(playlist).getId();
     }
 
-    public void delete(Playlist playlist) {
+    public void deletePlaylistEntity(Playlist playlist) {
         playlistRepository.delete(playlist);
         // playlistmusic의 delete도 처리
     }

--- a/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
@@ -40,7 +40,7 @@ public class PlaylistMusicController {
     }
 
     @GetMapping("/{playlistId}")
-    @Operation(summary = "playlist 속 노래 조회하기")
+    @Operation(summary = "playlist 속 노래 조회하기", description = "cursor 파라미터의 경우, cursor + 1번째부터 데이터를 조회하는데 사용됩니다.")
     public ApiResponse<?> getMusic(
             @PathVariable ("playlistId") Long playlistId,
             @RequestParam (name = "playlist 속 노래 순서") Long cursor,

--- a/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
@@ -1,0 +1,68 @@
+package com.munecting.api.domain.playListMusic.controller;
+
+import com.munecting.api.domain.playListMusic.dto.requestDto.PlaylistMusicPlayOrderUpdateRequestDto;
+import com.munecting.api.domain.playListMusic.dto.requestDto.PlaylistMusicRequestDto;
+import com.munecting.api.domain.playListMusic.service.PlaylistMusicService;
+import com.munecting.api.domain.spotify.dto.MusicResponseDto;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.PagedResponseDto;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/playlistMusic")
+@Tag(name = "playlistMusic", description = "playlist 속 노래 관련 api")
+public class PlaylistMusicController {
+
+    private final PlaylistMusicService playlistMusicService;
+
+    @PostMapping("/")
+    @Operation(summary = "playlist에 노래 추가하기")
+    public ApiResponse<?> addMusic(
+            @RequestBody PlaylistMusicRequestDto playlistMusicRequestDto) {
+        String trackId = playlistMusicService.addMusic(playlistMusicRequestDto);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), trackId);
+    }
+
+    @GetMapping("/{playlistId}")
+    @Operation(summary = "playlist 속 노래 조회하기")
+    public ApiResponse<?> getMusic(
+            @PathVariable ("playlistId") Long playlistId,
+            @RequestParam (name = "playlist 속 노래 순서") Long cursor,
+            @RequestParam (name = "한 번에 읽어올 노래 개수") int limit) {
+        PagedResponseDto<MusicResponseDto> musicResponseDtoList = playlistMusicService.getMusic(playlistId, cursor, limit);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
+    }
+
+    @DeleteMapping("/")
+    @Operation(summary = "playlist에서 노래 삭제하기")
+    public ApiResponse<?> deleteMusic(
+            @RequestBody PlaylistMusicRequestDto playlistMusicRequestDto) {
+        String trackId = playlistMusicService.deleteMusic(playlistMusicRequestDto);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), trackId);
+    }
+
+    @PatchMapping("/{playlistId}")
+    @Operation(summary = "playlist 속 노래 순서 변경하기")
+    public ApiResponse<?> updatePlayOrder(
+            @PathVariable ("playlistId") Long playlistId,
+            @RequestBody PlaylistMusicPlayOrderUpdateRequestDto playlistMusicPlayOrderUpdateRequestDto) {
+        Long id = playlistMusicService.updatePlayOrder(playlistId, playlistMusicPlayOrderUpdateRequestDto);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
+    }
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
@@ -53,7 +53,7 @@ public class PlaylistMusicController {
     @Operation(summary = "playlist에서 노래 삭제하기")
     public ApiResponse<?> deleteMusic(
             @RequestBody PlaylistMusicRequestDto playlistMusicRequestDto) {
-        String trackId = playlistMusicService.deleteMusic(playlistMusicRequestDto);
+        String trackId = playlistMusicService.deleteMusicFromPlaylist(playlistMusicRequestDto);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), trackId);
     }
 

--- a/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/controller/PlaylistMusicController.java
@@ -43,8 +43,8 @@ public class PlaylistMusicController {
     @Operation(summary = "playlist 속 노래 조회하기", description = "cursor 파라미터의 경우, cursor + 1번째부터 데이터를 조회하는데 사용됩니다.")
     public ApiResponse<?> getMusic(
             @PathVariable ("playlistId") Long playlistId,
-            @RequestParam (name = "playlist 속 노래 순서") Long cursor,
-            @RequestParam (name = "한 번에 읽어올 노래 개수") int limit) {
+            @RequestParam (name = "cursor") Long cursor,
+            @RequestParam (name = "limit") int limit) {
         PagedResponseDto<MusicResponseDto> musicResponseDtoList = playlistMusicService.getMusic(playlistId, cursor, limit);
         return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), musicResponseDtoList);
     }

--- a/src/main/java/com/munecting/api/domain/playListMusic/dao/PlaylistMusicRepository.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/dao/PlaylistMusicRepository.java
@@ -1,0 +1,22 @@
+package com.munecting.api.domain.playListMusic.dao;
+
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusicId;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaylistMusicRepository extends JpaRepository<PlaylistMusic, PlaylistMusicId> {
+
+    @Query("SELECT pm FROM PlaylistMusic pm WHERE pm.id.playlistId = :playlistId AND pm.playOrder > :playOrder")
+    Page<PlaylistMusic> findByPlaylistIdAndOrderGreaterThan(@Param("playlistId") Long playlistId, @Param("playOrder") Long playOrder, Pageable pageable);
+
+    @Query("SELECT COUNT(pm) FROM PlaylistMusic pm WHERE pm.id.playlistId = :playlistId")
+    long countByPlaylistId(@Param("playlistId") Long playlistId);
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicPlayOrderRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicPlayOrderRequestDto.java
@@ -1,0 +1,16 @@
+package com.munecting.api.domain.playListMusic.dto.requestDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class PlaylistMusicPlayOrderRequestDto {
+
+    private String trackId;
+
+    private Long playOrder;
+
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicPlayOrderUpdateRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicPlayOrderUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.munecting.api.domain.playListMusic.dto.requestDto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaylistMusicPlayOrderUpdateRequestDto {
+
+    private List<PlaylistMusicPlayOrderRequestDto> playlistMusicPlayOrderRequestDtoList;
+
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/dto/requestDto/PlaylistMusicRequestDto.java
@@ -1,0 +1,16 @@
+package com.munecting.api.domain.playListMusic.dto.requestDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class PlaylistMusicRequestDto {
+
+    private Long playlistId;
+
+    private String trackId;
+
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusic.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusic.java
@@ -1,6 +1,7 @@
 package com.munecting.api.domain.playListMusic.entity;
 
 import com.munecting.api.global.common.domain.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -20,4 +21,17 @@ public class PlaylistMusic extends BaseEntity {
 
     @EmbeddedId
     private PlaylistMusicId id;
+
+    @Column(name = "play_order")
+    private Long playOrder;
+
+    public static PlaylistMusic toEntity (PlaylistMusicId playlistMusicId) {
+        return PlaylistMusic.builder()
+                .id(playlistMusicId)
+                .build();
+    }
+
+    public void updatePlayOrder (Long order) {
+        this.playOrder = order;
+    }
 }

--- a/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusicId.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/entity/PlaylistMusicId.java
@@ -5,7 +5,15 @@ import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Embeddable
 public class PlaylistMusicId implements Serializable {
 
@@ -13,18 +21,25 @@ public class PlaylistMusicId implements Serializable {
     private Long playlistId;
 
     @NotNull
-    private String musicUri;
+    private String trackId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PlaylistMusicId that = (PlaylistMusicId) o;
-        return Objects.equals(playlistId, that.playlistId) && Objects.equals(musicUri, that.musicUri);
+        return Objects.equals(playlistId, that.playlistId) && Objects.equals(trackId, that.trackId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(playlistId, musicUri);
+        return Objects.hash(playlistId, trackId);
+    }
+
+    public static PlaylistMusicId toEntity (Long playlistId, String trackId) {
+        return PlaylistMusicId.builder()
+                .playlistId(playlistId)
+                .trackId(trackId)
+                .build();
     }
 }

--- a/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
@@ -1,0 +1,106 @@
+package com.munecting.api.domain.playListMusic.service;
+
+import com.munecting.api.domain.playList.entity.Playlist;
+import com.munecting.api.domain.playList.service.PlaylistService;
+import com.munecting.api.domain.playListMusic.dao.PlaylistMusicRepository;
+import com.munecting.api.domain.playListMusic.dto.requestDto.PlaylistMusicPlayOrderRequestDto;
+import com.munecting.api.domain.playListMusic.dto.requestDto.PlaylistMusicPlayOrderUpdateRequestDto;
+import com.munecting.api.domain.playListMusic.dto.requestDto.PlaylistMusicRequestDto;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusicId;
+import com.munecting.api.domain.spotify.dto.MusicResponseDto;
+import com.munecting.api.domain.spotify.dto.SpotifyDtoMapper;
+import com.munecting.api.domain.spotify.service.SpotifyService;
+import com.munecting.api.global.common.dto.response.GeneralException;
+import com.munecting.api.global.common.dto.response.PagedResponseDto;
+import com.munecting.api.global.common.dto.response.Status;
+import com.wrapper.spotify.model_objects.specification.Track;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PlaylistMusicService {
+
+    private final PlaylistMusicRepository playlistMusicRepository;
+    private final PlaylistService playlistService;
+    private final SpotifyService spotifyService;
+    private final SpotifyDtoMapper spotifyDtoMapper;
+
+    @Transactional
+    public String addMusic(PlaylistMusicRequestDto playlistMusicRequestDto) {
+        Long playlistId = playlistMusicRequestDto.getPlaylistId();
+        String trackId = playlistMusicRequestDto.getTrackId();
+        Playlist playlist = playlistService.findPlaylistById(playlistId);
+        // trackId로 스포티파이에 존재하는 track인지 확인하는 로직
+        PlaylistMusicId playlistMusicId = PlaylistMusicId.toEntity(playlistId, trackId);
+        PlaylistMusic playlistMusic = PlaylistMusic.toEntity(playlistMusicId);
+        long order = playlistMusicRepository.countByPlaylistId(playlistId);
+        playlistMusic.updatePlayOrder(order + 1);
+        save(playlistMusic);
+        return trackId;
+    }
+
+    @Transactional
+    public PagedResponseDto<MusicResponseDto> getMusic(Long playlistId, Long cursor, int limit) {
+        Playlist playlist = playlistService.findPlaylistById(playlistId);
+        cursor = cursor == null ? 0 : cursor;
+        Pageable pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "playOrder"));
+        Page<PlaylistMusic> playlistMusicList = playlistMusicRepository.findByPlaylistIdAndOrderGreaterThan(playlistId, cursor, pageable);
+        List<String> trackIdList = playlistMusicList.stream()
+                .map(playlistMusic -> playlistMusic.getId().getTrackId())
+                .toList();
+        List<MusicResponseDto> musicResponseDtoList = trackIdList.stream()
+                .map(spotifyService::getTrack)
+                .collect(Collectors.toList());
+        Page<MusicResponseDto> musicResponseDtoPage = new PageImpl<>(musicResponseDtoList, pageable, playlistMusicList.getTotalElements());
+
+        return new PagedResponseDto<>(musicResponseDtoPage);
+    }
+
+    public Long updatePlayOrder(Long playlistId, PlaylistMusicPlayOrderUpdateRequestDto playlistMusicPlayOrderUpdateRequestDto) {
+        Playlist playlist = playlistService.findPlaylistById(playlistId);
+        playlistMusicPlayOrderUpdateRequestDto.getPlaylistMusicPlayOrderRequestDtoList().stream()
+                .forEach(playlistMusicPlayOrderRequestDto -> {
+                    String trackId = playlistMusicPlayOrderRequestDto.getTrackId();
+                    Long playOrder = playlistMusicPlayOrderRequestDto.getPlayOrder();
+                    PlaylistMusicId playlistMusicId = PlaylistMusicId.toEntity(playlistId, trackId);
+                    PlaylistMusic playlistMusic = getPlaylistById(playlistMusicId);
+                    playlistMusic.updatePlayOrder(playOrder);
+                    playlistMusicRepository.save(playlistMusic);
+                });
+        return playlist.getId();
+    }
+
+    @Transactional
+    public String deleteMusic(PlaylistMusicRequestDto playlistMusicRequestDto) {
+        Long playlistId = playlistMusicRequestDto.getPlaylistId();
+        String trackId = playlistMusicRequestDto.getTrackId();
+        PlaylistMusicId playlistMusicId = PlaylistMusicId.toEntity(playlistId, trackId);
+        PlaylistMusic playlistMusic = getPlaylistById(playlistMusicId);
+        delete(playlistMusic);
+        return trackId;
+    }
+
+    public void save(PlaylistMusic playlistMusic) {
+        playlistMusicRepository.save(playlistMusic);
+    }
+
+    public void delete(PlaylistMusic playlistMusic) {
+        playlistMusicRepository.delete(playlistMusic);
+    }
+
+    public PlaylistMusic getPlaylistById (PlaylistMusicId playlistMusicId) {
+        return playlistMusicRepository.findById(playlistMusicId)
+                .orElseThrow(() -> new GeneralException(Status.PLAY_LIST_MUSIC_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
@@ -33,14 +33,13 @@ public class PlaylistMusicService {
     private final PlaylistMusicRepository playlistMusicRepository;
     private final PlaylistService playlistService;
     private final SpotifyService spotifyService;
-    private final SpotifyDtoMapper spotifyDtoMapper;
 
     @Transactional
     public String addMusic(PlaylistMusicRequestDto playlistMusicRequestDto) {
         Long playlistId = playlistMusicRequestDto.getPlaylistId();
         String trackId = playlistMusicRequestDto.getTrackId();
-        Playlist playlist = playlistService.findPlaylistById(playlistId);
-        // trackId로 스포티파이에 존재하는 track인지 확인하는 로직
+        playlistService.findPlaylistById(playlistId);
+        spotifyService.getTrack(trackId);
         PlaylistMusicId playlistMusicId = PlaylistMusicId.toEntity(playlistId, trackId);
         PlaylistMusic playlistMusic = PlaylistMusic.toEntity(playlistMusicId);
         long order = playlistMusicRepository.countByPlaylistId(playlistId);

--- a/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
+++ b/src/main/java/com/munecting/api/domain/playListMusic/service/PlaylistMusicService.java
@@ -44,7 +44,7 @@ public class PlaylistMusicService {
         PlaylistMusic playlistMusic = PlaylistMusic.toEntity(playlistMusicId);
         long order = playlistMusicRepository.countByPlaylistId(playlistId);
         playlistMusic.updatePlayOrder(order + 1);
-        save(playlistMusic);
+        savePlaylistMusicEntity(playlistMusic);
         return trackId;
     }
 
@@ -80,20 +80,20 @@ public class PlaylistMusicService {
     }
 
     @Transactional
-    public String deleteMusic(PlaylistMusicRequestDto playlistMusicRequestDto) {
+    public String deleteMusicFromPlaylist(PlaylistMusicRequestDto playlistMusicRequestDto) {
         Long playlistId = playlistMusicRequestDto.getPlaylistId();
         String trackId = playlistMusicRequestDto.getTrackId();
         PlaylistMusicId playlistMusicId = PlaylistMusicId.toEntity(playlistId, trackId);
         PlaylistMusic playlistMusic = getPlaylistById(playlistMusicId);
-        delete(playlistMusic);
+        deletePlaylistMusicEntity(playlistMusic);
         return trackId;
     }
 
-    public void save(PlaylistMusic playlistMusic) {
+    public void savePlaylistMusicEntity(PlaylistMusic playlistMusic) {
         playlistMusicRepository.save(playlistMusic);
     }
 
-    public void delete(PlaylistMusic playlistMusic) {
+    public void deletePlaylistMusicEntity(PlaylistMusic playlistMusic) {
         playlistMusicRepository.delete(playlistMusic);
     }
 

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -121,7 +121,7 @@ public class SpotifyService {
                     .map(trackSimplified -> spotifyDtoMapper.convertToTrackResponseDto(trackSimplified))
                     .collect(Collectors.toList());
         } catch (IOException | ParseException | SpotifyWebApiException ex) {
-            throw new RuntimeException(ex);
+            throw new GeneralException(Status.ALBUM_NOT_FOUND);
         }
 
     }
@@ -141,7 +141,7 @@ public class SpotifyService {
                     .map(albumSimplified -> spotifyDtoMapper.convertToAlbumResponseDto(albumSimplified))
                     .collect(Collectors.toList());
         } catch (IOException | ParseException | SpotifyWebApiException ex) {
-            throw new RuntimeException(ex);
+            throw new GeneralException(Status.ARTIST_NOT_FOUND);
         }
 
     }

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -5,6 +5,8 @@ import com.munecting.api.domain.spotify.dto.AlbumResponseDto;
 import com.munecting.api.domain.spotify.dto.ArtistResponseDto;
 import com.munecting.api.domain.spotify.dto.MusicResponseDto;
 import com.munecting.api.domain.spotify.dto.SpotifyDtoMapper;
+import com.munecting.api.global.common.dto.response.GeneralException;
+import com.munecting.api.global.common.dto.response.Status;
 import com.neovisionaries.i18n.CountryCode;
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.enums.ModelObjectType;
@@ -153,7 +155,7 @@ public class SpotifyService {
             Track track = getTrackRequest.execute();
             return spotifyDtoMapper.convertToTrackResponseDto(track);
         } catch (IOException | ParseException | SpotifyWebApiException ex) {
-            throw new RuntimeException(ex);
+            throw new GeneralException(Status.TRACK_NOT_FOUND);
         }
 
     }

--- a/src/main/java/com/munecting/api/global/common/dto/response/PagedResponseDto.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/PagedResponseDto.java
@@ -1,0 +1,30 @@
+package com.munecting.api.global.common.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Setter
+@Getter
+public class PagedResponseDto<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasPrevious;
+    private boolean hasNext;
+
+    public PagedResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.hasPrevious = page.hasPrevious();
+        this.hasNext = page.hasNext();
+    }
+
+}

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -18,6 +18,10 @@ public enum Status {
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, "COMMON409", "이미 생성되었습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에 오류가 발생했습니다."),
+
+    //Playlist 오류 응답
+    PLAY_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLIST404", "플레이 리스트가 존재하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -19,6 +19,9 @@ public enum Status {
     CONFLICT(HttpStatus.CONFLICT, "COMMON409", "이미 생성되었습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에 오류가 발생했습니다."),
 
+    //Spotify 오류 응답
+    TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "SPOTIFY404", "스포티파이에서 track 정보를 찾을 수 없습니다."),
+
     //Playlist 오류 응답
     PLAY_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLIST404", "플레이 리스트가 존재하지 않습니다."),
 

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -22,6 +22,9 @@ public enum Status {
     //Playlist 오류 응답
     PLAY_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLIST404", "플레이 리스트가 존재하지 않습니다."),
 
+    //PlaylistMusic 오류 응답
+    PLAY_LIST_MUSIC_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLISTMUSIC404", "플레이 리스트에 해당 노래가 존재하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -20,7 +20,9 @@ public enum Status {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버에 오류가 발생했습니다."),
 
     //Spotify 오류 응답
-    TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "SPOTIFY404", "스포티파이에서 track 정보를 찾을 수 없습니다."),
+    TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "SPOTIFY_TRACK404", "스포티파이에서 track 정보를 찾을 수 없습니다."),
+    ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "SPOTIFY_ARTIST404", "스포티파이에서 artist 정보를 찾을 수 없습니다."),
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "SPOTIFY_ALBUM404", "스포티파이에서 album 정보를 찾을 수 없습니다."),
 
     //Playlist 오류 응답
     PLAY_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLIST404", "플레이 리스트가 존재하지 않습니다."),


### PR DESCRIPTION
## 이슈 번호
#8 

## 작업 내용
playlist와 playlist속 노래를 다루는 로직을 만들었습니다.

playlist의 기본적인 CURD와 playlist안의 노래의 CURD + 순서 변경 로직이 주된 작업 내용입니다.
특히 노래 순서 변경 로직은 IOS 남선우님과 협의 후에 API를 작성완료 했습니다.
 - PlayList 생성
 - PlayList 이름 수정
 - 내 PlayList 조회
 - PlayList 삭제
 - playList에서 노래 조회하기
 - PlayList에 노래 추가
 - PlayList에서 노래 삭제하기
 - PlayList에서 노래 순서 바꾸기
 - trackId로 Spotify에 존재하는 노래인지 판별하는 로직

## 스웨거 스크린샷
**내 playlist 조회**
![image](https://github.com/user-attachments/assets/d27e46d1-5b7d-4ff5-94a3-3eabd61d090c)
**playlist 속 노래 조회**
<img width="728" alt="image" src="https://github.com/user-attachments/assets/66e9042a-ebfe-40f5-87be-2964dc6ac2ed">
**playlist 속 노래 순서 변경**
![image](https://github.com/user-attachments/assets/3795b00e-d659-4f50-8e30-a6c45a7e184b)

## ETC
사용자의 로그인 정보를 추출하는 로직을 인증 부분에서 구현해주시면 좋을 것 같습니다! 현재는 userId를 파라미터로 받아오고 있는데 이를 삭제할 예정입니다.
https://mingyum119.tistory.com/250 해당 내용을 참고해주세요! "JWT로 로그인 정보 추출하기"라고 검색하시면 많은 자료를 찾으실 수 있습니다.
