### PR TITLE
댓글 관련 API 작성 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.postgresql:postgresql:42.7.2'
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
@@ -1,0 +1,70 @@
+package com.munecting.api.domain.comment.controller;
+
+import com.munecting.api.domain.comment.dto.CommentRequestDto;
+import com.munecting.api.domain.comment.dto.CommentResponseDto;
+import com.munecting.api.domain.comment.entity.Comment;
+import com.munecting.api.domain.comment.service.CommentService;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.PagedResponseDto;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/comment")
+@Tag(name = "comment", description = "댓글 관련 api")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/")
+    @Operation(summary = "댓글 등록하기")
+    public ApiResponse<?> createComment(
+            @RequestBody CommentRequestDto commentRequestDto) {
+        Long id = commentService.createComment(commentRequestDto);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), id);
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제하기")
+    public ApiResponse<?> deleteComment(
+            @PathVariable Long commentId) {
+        Long id = commentService.deleteComment(commentId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
+    }
+
+    @PatchMapping("/{commentId}")
+    @Operation(summary = "댓글 수정하기")
+    public ApiResponse<?> deleteComment(
+            @PathVariable (name = "commentId") Long commentId,
+            @RequestBody CommentRequestDto commentRequestDto) {
+        Long id = commentService.updateComment(commentId, commentRequestDto);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
+    }
+
+    @GetMapping("/{trackId}")
+    @Operation(summary = "댓글 조회하기")
+    public ApiResponse<?> getCommentsByTrackId(
+            @PathVariable (name = "trackId") String trackId,
+            @RequestParam (name = "cursor") LocalDateTime cursor,
+            @RequestParam (name = "limit") int limit) {
+        PagedResponseDto<CommentResponseDto> commentResponseDtoList = commentService.getCommentsByTrackId(trackId, cursor, limit);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), commentResponseDtoList);
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
@@ -26,13 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/comment")
-@Tag(name = "comment", description = "댓글 관련 api")
+@RequestMapping("/tracks")
+@Tag(name = "comments", description = "댓글 관련 api")
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/")
+    @PostMapping("/comments")
     @Operation(summary = "댓글 등록하기")
     public ApiResponse<?> createComment(
             @RequestBody CommentRequestDto commentRequestDto) {
@@ -48,16 +48,16 @@ public class CommentController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
     }
 
-    @PatchMapping("/{commentId}")
+    @PatchMapping("/comments/{commentId}")
     @Operation(summary = "댓글 수정하기")
-    public ApiResponse<?> deleteComment(
+    public ApiResponse<?> updateComment(
             @PathVariable (name = "commentId") Long commentId,
             @RequestBody CommentRequestDto commentRequestDto) {
         Long id = commentService.updateComment(commentId, commentRequestDto);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
     }
 
-    @GetMapping("/{trackId}")
+    @GetMapping("/{trackId}/comments")
     @Operation(summary = "댓글 조회하기")
     public ApiResponse<?> getCommentsByTrackId(
             @PathVariable (name = "trackId") String trackId,

--- a/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
@@ -1,0 +1,22 @@
+package com.munecting.api.domain.comment.dao;
+
+import com.munecting.api.domain.comment.entity.Comment;
+import com.munecting.api.domain.playList.entity.Playlist;
+import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c WHERE c.trackId = :trackId AND (:cursorStr IS NULL OR c.createdAt < CAST(:cursorStr AS TIMESTAMP)) ORDER BY c.createdAt DESC")
+    Page<Comment> findCommentsByTrackIdWithCursor(
+            @Param("trackId") String trackId, @Param("cursorStr") String cursorStr, Pageable pageable);
+}

--- a/src/main/java/com/munecting/api/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/comment/dto/CommentRequestDto.java
@@ -1,0 +1,18 @@
+package com.munecting.api.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class CommentRequestDto {
+
+    private Long userId;
+
+    private String trackId;
+
+    private String content;
+
+}

--- a/src/main/java/com/munecting/api/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/comment/dto/CommentRequestDto.java
@@ -1,10 +1,8 @@
 package com.munecting.api.domain.comment.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-@Builder
 @Getter
 @Setter
 public class CommentRequestDto {

--- a/src/main/java/com/munecting/api/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,38 @@
+package com.munecting.api.domain.comment.dto;
+
+import com.munecting.api.domain.comment.entity.Comment;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.cglib.core.Local;
+
+@Builder
+@Getter
+@Setter
+public class CommentResponseDto {
+
+    private Long userId;
+
+    private String trackId;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+    
+    // 내가 쓴 댓글인지 판별하는 필드 필요 -> 인증 부분 완성되면 추가 예정
+
+    public static CommentResponseDto toDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .userId(comment.getUserId())
+                .trackId(comment.getTrackId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/comment/entity/Comment.java
+++ b/src/main/java/com/munecting/api/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.munecting.api.domain.comment.entity;
 
+import com.munecting.api.domain.comment.dto.CommentRequestDto;
 import com.munecting.api.global.common.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -29,8 +30,21 @@ public class Comment extends BaseEntity {
     private Long userId;
 
     @NotNull
-    private String musicUri;
+    private String trackId;
 
     @NotNull
     private String content;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public static Comment toEntity(CommentRequestDto commentRequestDto) {
+        return Comment.builder()
+                .userId(commentRequestDto.getUserId())
+                .trackId(commentRequestDto.getTrackId())
+                .content(commentRequestDto.getContent())
+                .build();
+    }
+
 }

--- a/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.munecting.api.domain.comment.dao.CommentRepository;
 import com.munecting.api.domain.comment.dto.CommentRequestDto;
 import com.munecting.api.domain.comment.dto.CommentResponseDto;
 import com.munecting.api.domain.comment.entity.Comment;
+import com.munecting.api.domain.spotify.service.SpotifyService;
 import com.munecting.api.global.common.dto.response.GeneralException;
 import com.munecting.api.global.common.dto.response.PagedResponseDto;
 import com.munecting.api.global.common.dto.response.Status;
@@ -23,8 +24,11 @@ import org.springframework.stereotype.Service;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final SpotifyService spotifyService;
 
     public Long createComment(CommentRequestDto commentRequestDto) {
+        String trackId = commentRequestDto.getTrackId();
+        spotifyService.getTrack(trackId);
         Comment comment = Comment.toEntity(commentRequestDto);
         Long id = saveCommentEntity(comment);
         return id;

--- a/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
@@ -1,0 +1,71 @@
+package com.munecting.api.domain.comment.service;
+
+import com.munecting.api.domain.comment.dao.CommentRepository;
+import com.munecting.api.domain.comment.dto.CommentRequestDto;
+import com.munecting.api.domain.comment.dto.CommentResponseDto;
+import com.munecting.api.domain.comment.entity.Comment;
+import com.munecting.api.global.common.dto.response.GeneralException;
+import com.munecting.api.global.common.dto.response.PagedResponseDto;
+import com.munecting.api.global.common.dto.response.Status;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    public Long createComment(CommentRequestDto commentRequestDto) {
+        Comment comment = Comment.toEntity(commentRequestDto);
+        Long id = saveCommentEntity(comment);
+        return id;
+    }
+
+    public Long deleteComment(Long commentId) {
+        Comment comment = getCommentEntityById(commentId);
+        deleteCommentEntity(comment);
+        return commentId;
+    }
+
+    public Long updateComment(Long commentId, CommentRequestDto commentRequestDto) {
+        Comment comment = getCommentEntityById(commentId);
+        comment.updateContent(commentRequestDto.getContent());
+        return saveCommentEntity(comment);
+    }
+
+    public PagedResponseDto<CommentResponseDto> getCommentsByTrackId(String trackId, LocalDateTime cursor, int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        //Timestamp cursorTimestamp = LocalDateTimeUtil.toTimestamp(cursor);
+        Page<Comment> pagedComment = getCommentsByTrackIdWithCursor(trackId, cursor, pageable);
+        Page<CommentResponseDto> pagedCommentResponseDto = pagedComment.map(CommentResponseDto::toDto);
+        return new PagedResponseDto<>(pagedCommentResponseDto);
+    }
+
+    public Long saveCommentEntity(Comment comment) {
+        return commentRepository.save(comment).getId();
+    }
+
+    public void deleteCommentEntity(Comment comment) {
+        commentRepository.delete(comment);
+    }
+
+    public Page<Comment> getCommentsByTrackIdWithCursor(String trackId, LocalDateTime cursor, Pageable pageable) {
+        log.info(String.valueOf(cursor));
+        return commentRepository.findCommentsByTrackIdWithCursor(trackId, cursor.toString(), pageable);
+    }
+
+    public Comment getCommentEntityById(Long id) {
+        return commentRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(Status.COMMENT_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -30,6 +30,9 @@ public enum Status {
     //PlaylistMusic 오류 응답
     PLAY_LIST_MUSIC_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAYLISTMUSIC404", "플레이 리스트에 해당 노래가 존재하지 않습니다."),
 
+    //댓글 오류 응답
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "댓글이 존재하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/common/util/StringToLocalDateTimeConverter.java
+++ b/src/main/java/com/munecting/api/global/common/util/StringToLocalDateTimeConverter.java
@@ -1,0 +1,17 @@
+package com.munecting.api.global.common.util;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+@Component
+public class StringToLocalDateTimeConverter implements Converter<String, LocalDateTime> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Override
+    public LocalDateTime convert(String source) {
+        return LocalDateTime.parse(source, FORMATTER);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring :
       hibernate:
         show_sql: true
         format_sql: true
+        jdbc:
+          timezone: Asia/Seoul
 
   datasource:
     url: jdbc:${DATASOURCE}://${HOST}:${PORT}/${TABLE}


### PR DESCRIPTION
노래에 대한 댓글을 작성, 수정, 삭제, 조회할 수 있는 API를 작성했습니다.

아래는 커서 기반으로 댓글을 조회하는 API입니다. 
최신순으로 정렬했으며, 커서는 이전에 읽은 마지막 댓글의 createdAt입니다. 
따라서 cursor보다 더 이전의 createdAt을 가진 댓글을 조회하도록 합니다.
<img width="503" alt="image" src="https://github.com/user-attachments/assets/4d3a585a-c6e8-4cfa-93ac-2a8e2d4466ed">
