### PR TITLE
회원 로그아웃 및 탈퇴 API 구현 완료, Comment service 메소드 리팩토링

### DIFF
--- a/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/munecting/api/domain/comment/controller/CommentController.java
@@ -2,7 +2,6 @@ package com.munecting.api.domain.comment.controller;
 
 import com.munecting.api.domain.comment.dto.CommentRequestDto;
 import com.munecting.api.domain.comment.dto.CommentResponseDto;
-import com.munecting.api.domain.comment.entity.Comment;
 import com.munecting.api.domain.comment.service.CommentService;
 import com.munecting.api.global.common.dto.response.ApiResponse;
 import com.munecting.api.global.common.dto.response.PagedResponseDto;
@@ -12,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -44,7 +42,7 @@ public class CommentController {
     @Operation(summary = "댓글 삭제하기")
     public ApiResponse<?> deleteComment(
             @PathVariable Long commentId) {
-        Long id = commentService.deleteComment(commentId);
+        Long id = commentService.deleteCommentById(commentId);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), id);
     }
 

--- a/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
@@ -1,10 +1,6 @@
 package com.munecting.api.domain.comment.dao;
 
 import com.munecting.api.domain.comment.entity.Comment;
-import com.munecting.api.domain.playList.entity.Playlist;
-import com.munecting.api.domain.playListMusic.entity.PlaylistMusic;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,10 +9,11 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment c WHERE c.trackId = :trackId AND (:cursorStr IS NULL OR c.createdAt < CAST(:cursorStr AS TIMESTAMP)) ORDER BY c.createdAt DESC")
     Page<Comment> findCommentsByTrackIdWithCursor(
             @Param("trackId") String trackId, @Param("cursorStr") String cursorStr, Pageable pageable);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
@@ -72,4 +72,17 @@ public class CommentService {
                 .orElseThrow(() -> new EntityNotFoundException(Status.COMMENT_NOT_FOUND));
     }
 
+    public Long deleteCommentById(Long commentId) {
+        Comment comment = getCommentById(commentId);
+        deleteComment(comment);
+        return commentId;
+    }
+
+    public void deleteComment(Comment comment) {
+        commentRepository.delete(comment);
+    }
+
+    public void deleteCommentsByUserId(Long userId) {
+        commentRepository.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -4,4 +4,5 @@ import com.munecting.api.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -1,7 +1,18 @@
 package com.munecting.api.domain.like.service;
 
+import com.munecting.api.domain.like.dao.LikeRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public void deleteLikesByUserId(Long userId) {
+        likeRepository.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/munecting/api/domain/uploadedMusic/dao/UploadedMusicRepository.java
+++ b/src/main/java/com/munecting/api/domain/uploadedMusic/dao/UploadedMusicRepository.java
@@ -28,4 +28,6 @@ public interface UploadedMusicRepository extends JpaRepository<UploadedMusic, Lo
             @Param("longitude") double longitude,
             @Param("radius") Integer radius
     );
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/munecting/api/domain/uploadedMusic/service/MusicService.java
+++ b/src/main/java/com/munecting/api/domain/uploadedMusic/service/MusicService.java
@@ -7,7 +7,6 @@ import com.munecting.api.domain.uploadedMusic.dto.MusicRequestDto;
 import com.munecting.api.domain.uploadedMusic.dto.UploadedMusicResponseDto;
 import com.munecting.api.domain.uploadedMusic.entity.UploadedMusic;
 import com.munecting.api.domain.user.entity.User;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +45,9 @@ public class MusicService {
 
     private List<UploadedMusic> getUploadedMusicByLocationAndRadius(Double latitude, Double longitude, Integer radius) {
         return uploadedMusicRepository.findUploadedMusicByLocationAndRadius(latitude, longitude, radius);
+    }
+
+    public void deleteUploadedMusicsByUserId(Long userId) {
+        uploadedMusicRepository.deleteByUserId(userId);
     }
 }

--- a/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.munecting.api.domain.user.dto.RefreshTokenRequestDto;
 import com.munecting.api.domain.user.dto.UserLoginRequestDto;
 import com.munecting.api.domain.user.dto.UserTokenResponseDto;
 import com.munecting.api.domain.user.service.AuthService;
+import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
 import com.munecting.api.global.common.dto.response.Status;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +45,16 @@ public class AuthController {
         UserTokenResponseDto dto = authService.getOrCreateUser(userLoginRequestDto);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃")
+    public ApiResponse<?> logout(
+            @UserId Long userId
+    ) {
+        authService.logout(userId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), null);
+    }
+
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급하기")

--- a/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
@@ -1,9 +1,10 @@
 package com.munecting.api.domain.user.controller;
 
 
-import com.munecting.api.domain.user.dto.RefreshTokenRequestDto;
-import com.munecting.api.domain.user.dto.UserLoginRequestDto;
-import com.munecting.api.domain.user.dto.UserTokenResponseDto;
+import com.munecting.api.domain.user.dto.request.LogoutRequestDto;
+import com.munecting.api.domain.user.dto.request.RefreshTokenRequestDto;
+import com.munecting.api.domain.user.dto.request.LoginRequestDto;
+import com.munecting.api.domain.user.dto.response.UserTokenResponseDto;
 import com.munecting.api.domain.user.service.AuthService;
 import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
@@ -40,18 +41,18 @@ public class AuthController {
             summary = "로그인 또는 회원가입하기",
             description = "회원가입이 되어 있는 경우 로그인을 수행, 그렇지 않은 경우 회원가입을 수행합니다.")
     public ApiResponse<?> login(
-            @RequestBody @Valid UserLoginRequestDto userLoginRequestDto
+            @RequestBody @Valid LoginRequestDto loginRequestDto
     ) {
-        UserTokenResponseDto dto = authService.getOrCreateUser(userLoginRequestDto);
+        UserTokenResponseDto dto = authService.getOrCreateUser(loginRequestDto);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
     }
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃")
     public ApiResponse<?> logout(
-            @UserId Long userId
-    ) {
-        authService.logout(userId);
+            @RequestBody @Valid LogoutRequestDto logoutRequestDto
+            ) {
+        authService.logout(logoutRequestDto);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), null);
     }
 

--- a/src/main/java/com/munecting/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/UserController.java
@@ -19,8 +19,10 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
 
-    @Operation(description = " access token을 통해 user id를 정상적으로 받아오는지 확인합니다. (삭제 예정)")
     @GetMapping("/test")
+    @Operation(
+            summary = "@UserId 테스트용 (삭제 예정)",
+            description = " access token을 통해 user id를 정상적으로 받아오는지 확인합니다. (삭제 예정)")
     public ApiResponse<?> test(
             @UserId Long userId
     ) {

--- a/src/main/java/com/munecting/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/UserController.java
@@ -9,13 +9,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@Tag(name = "user" , description = "user 관련 api")
+@RequestMapping("/api/users")
+@Tag(name = "user", description = "user 관련 api")
 public class UserController {
     private final UserService userService;
 
@@ -27,4 +27,12 @@ public class UserController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), userId);
     }
 
+    @DeleteMapping("/{userId}")
+    @Operation(summary = "회원 탈퇴")
+    public ApiResponse<?> deleteUser(
+            @PathVariable(name = "userId") Long userId
+    ) {
+        userService.deleteUser(userId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), null);
+    }
 }

--- a/src/main/java/com/munecting/api/domain/user/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/request/LoginRequestDto.java
@@ -1,11 +1,11 @@
-package com.munecting.api.domain.user.dto;
+package com.munecting.api.domain.user.dto.request;
 
 import com.munecting.api.domain.user.constant.SocialType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record UserLoginRequestDto(
+public record LoginRequestDto(
         @NotNull
         @Schema(description = "Identity Provider")
         SocialType socialType,

--- a/src/main/java/com/munecting/api/domain/user/dto/request/LogoutRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/request/LogoutRequestDto.java
@@ -1,0 +1,8 @@
+package com.munecting.api.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequestDto(
+        @NotBlank String accessToken
+) {
+}

--- a/src/main/java/com/munecting/api/domain/user/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/request/RefreshTokenRequestDto.java
@@ -1,4 +1,4 @@
-package com.munecting.api.domain.user.dto;
+package com.munecting.api.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/com/munecting/api/domain/user/dto/response/UserTokenResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/response/UserTokenResponseDto.java
@@ -1,4 +1,4 @@
-package com.munecting.api.domain.user.dto;
+package com.munecting.api.domain.user.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/munecting/api/domain/user/service/AuthService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/AuthService.java
@@ -132,7 +132,9 @@ public class AuthService {
         processLogout(userId);
     }
 
-    private Long getUserIdFromAccessToken(String token) {
+    private Long getUserIdFromAccessToken(String requestToken) {
+        String token = jwtProvider.extractAccessToken(requestToken);
+
         try {
             jwtProvider.validateTokenAtLogout(token);
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/munecting/api/domain/user/service/AuthService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/AuthService.java
@@ -124,4 +124,16 @@ public class AuthService {
     private String issueNewRefreshToken(Long userId) {
         return jwtProvider.getIssueToken(userId, false);
     }
+
+    public void logout(Long userId) {
+        String key = getRedisKey(userId);
+        String savedRefreshToken = redisTemplate.opsForValue().get(key);
+
+        if (savedRefreshToken != null) {
+            redisTemplate.delete(key);
+            log.info("User {} logged out successfully", userId);
+        } else {
+            log.info("User {} logged out, no refresh token found", userId);
+        }
+    }
 }

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -1,9 +1,18 @@
 package com.munecting.api.domain.user.service;
 
+import com.munecting.api.domain.comment.service.CommentService;
+import com.munecting.api.domain.like.service.LikeService;
+import com.munecting.api.domain.uploadedMusic.service.MusicService;
+import com.munecting.api.domain.user.dao.UserRepository;
+import com.munecting.api.domain.user.entity.User;
+import com.munecting.api.global.common.dto.response.Status;
+import com.munecting.api.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.munecting.api.global.common.dto.response.Status.USER_NOT_FOUND;
 
 @Slf4j
 @Transactional
@@ -11,5 +20,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserService {
 
+    private final UserRepository userRepository;
 
+    private final CommentService commentService;
+
+    private final LikeService likeService;
+
+    private final MusicService musicService;
+
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        deleteUserRelatedEntities(userId);
+        userRepository.delete(user);
+    }
+
+    private void deleteUserRelatedEntities(Long userId) {
+        commentService.deleteCommentsByUserId(userId);
+        likeService.deleteLikesByUserId(userId);
+        musicService.deleteUploadedMusicsByUserId(userId);
+    }
 }

--- a/src/main/java/com/munecting/api/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/munecting/api/global/auth/filter/JwtAuthenticationFilter.java
@@ -48,18 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         Optional<String> bearerToken = Optional.ofNullable(request.getHeader(authHeader));
         bearerToken.ifPresent(it -> {
-            String accessToken = extractAccessToken(it);
+            String accessToken = jwtProvider.extractAccessToken(it);
             jwtProvider.validateAccessToken(accessToken);
             setAuthentication(accessToken);
         });
         filterChain.doFilter(request, response);
-    }
-
-    public String extractAccessToken(String bearerToken) {
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(prefix)) {
-            return bearerToken.substring(7);
-        }
-        throw new UnauthorizedException(INVALID_TOKEN);
     }
 
     private void setAuthentication(String accessToken) {

--- a/src/main/java/com/munecting/api/global/auth/interceptor/UserAuthorizationInterceptor.java
+++ b/src/main/java/com/munecting/api/global/auth/interceptor/UserAuthorizationInterceptor.java
@@ -1,0 +1,72 @@
+package com.munecting.api.global.auth.interceptor;
+
+import com.munecting.api.global.auth.user.UserPrincipalDetails;
+import com.munecting.api.global.common.dto.response.Status;
+import com.munecting.api.global.error.exception.ForbiddenException;
+import com.munecting.api.global.error.exception.GeneralException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Component
+@Slf4j
+public class UserAuthorizationInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        // HTTP DELETE METHOD 요청만 handle
+        if (!"DELETE".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+
+        String userIdFromPath = extractUserIdFromPath(handler);
+        if (userIdFromPath == null) {
+            log.warn("user ID from path is null");
+            throw new GeneralException(Status.BAD_REQUEST);
+        }
+
+        Long requestedUserId = parseUserId(userIdFromPath);
+        if (requestedUserId == getUserFromToken().getId()) {
+            return true;
+        }
+
+        log.info("삭제 요청 id : {}, 액세스 토큰으로부터 추출한 id: {}", userIdFromPath, getUserFromToken().getId());
+        throw new ForbiddenException();
+    }
+
+    private UserPrincipalDetails getUserFromToken() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipalDetails userDetails = (UserPrincipalDetails) auth.getPrincipal();
+        return userDetails;
+    }
+
+    private String extractUserIdFromPath(Object handler) {
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+            PathVariable pv = handlerMethod.getMethodParameters()[0].getParameterAnnotation(PathVariable.class);
+
+            if (pv != null) {
+                String userId = ServletUriComponentsBuilder.fromCurrentRequest().build().getPathSegments().get(2);
+                return userId;
+            }
+        }
+        return null;
+    }
+
+    private Long parseUserId(String userIdFromPath) {
+        try {
+            return Long.valueOf(userIdFromPath);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid user ID format: {}", userIdFromPath, e);
+            throw new GeneralException(Status.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/munecting/api/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/munecting/api/global/auth/jwt/JwtProvider.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.security.Key;
@@ -157,6 +158,13 @@ public class JwtProvider {
         } catch (RuntimeException e) {
             throw new InternalServerException();
         }
+    }
+
+    public String extractAccessToken(String bearerToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(prefix)) {
+            return bearerToken.substring(7);
+        }
+        throw new UnauthorizedException(INVALID_TOKEN);
     }
 
 }

--- a/src/main/java/com/munecting/api/global/auth/resolver/UserIdArgumentResolver.java
+++ b/src/main/java/com/munecting/api/global/auth/resolver/UserIdArgumentResolver.java
@@ -1,5 +1,7 @@
-package com.munecting.api.global.auth.user;
+package com.munecting.api.global.auth.resolver;
 
+import com.munecting.api.global.auth.user.UserId;
+import com.munecting.api.global.auth.user.UserPrincipalDetails;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -23,6 +25,6 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
         UserPrincipalDetails principal = (UserPrincipalDetails) SecurityContextHolder.getContext()
                 .getAuthentication()
                 .getPrincipal();
-        return principal.getUser().getId();
+        return principal.getId();
     }
 }

--- a/src/main/java/com/munecting/api/global/auth/user/UserPrincipalDetails.java
+++ b/src/main/java/com/munecting/api/global/auth/user/UserPrincipalDetails.java
@@ -32,7 +32,11 @@ public class UserPrincipalDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return user.getPassword();
+        return null;
+    }
+
+    public Long getId() {
+        return user.getId();
     }
 
 }

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -40,6 +40,9 @@ public enum Status {
 
     //댓글 오류 응답
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "댓글이 존재하지 않습니다."),
+
+    // User 오류 응답
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 회원입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/config/WebConfig.java
+++ b/src/main/java/com/munecting/api/global/config/WebConfig.java
@@ -1,9 +1,11 @@
 package com.munecting.api.global.config;
 
-import com.munecting.api.global.auth.user.UserIdArgumentResolver;
+import com.munecting.api.global.auth.interceptor.UserAuthorizationInterceptor;
+import com.munecting.api.global.auth.resolver.UserIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -13,9 +15,16 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final UserIdArgumentResolver userIdArgumentResolver;
+    private final UserAuthorizationInterceptor userAuthorizationInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userIdArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userAuthorizationInterceptor)
+                .addPathPatterns("/api/users/{userId}");
     }
 }


### PR DESCRIPTION
## 이슈 번호
- close : #20 

## 작업 내용
- 로그아웃 API
- 탈퇴 API
- CommentService 일부 리팩토링

## 스크린샷

> 로그아웃 요청

![image](https://github.com/user-attachments/assets/c3a30b55-4028-4783-9e2d-f7ea0e9d143d)

> 탈퇴 요청

![image](https://github.com/user-attachments/assets/7546a9a6-172a-4b47-a6ee-498f19ab4114)

단 탈퇴 요청 user가 본인이 아니라면 탈퇴 불가능합니다.

예시) DELETE /api/users/3 요청 + 액세스 토큰으로부터 추출된 user id가 1인 경우 탈퇴 불가
![image](https://github.com/user-attachments/assets/d183e117-fc09-416f-b86e-7cd590c191cb)



## 확인 요청사항
- 기존 service 계층의 메소드 이름을 `***Entity`로 작성하는 형식은 "메소드명이 다소 길다"는 단점이 존재합니다. 예를 들어 `deleteCommentEntityByUserId`는 긴 이름으로 인해 가독성이 떨어지는데, 대신 `deleteCommentByUserId`를 사용한다면 간결한 이름으로 가독성을 개선할 수 있을 것입니다. 
- 따라서 기존 `delete+엔티티명+Entity` 의 작명 방식 대신` delete + 엔티티명`의 방식을 제안합니다. 이는  `Jpa repository method` 이름과도 구분되면서도 기존 컨벤션의 단점을 개선할 수 있는 장점을 가진다고 생각합니다. 해당 내용은 지난 회의 때 민주님과 논의를 마친 내용으로, 제안드린 내용으로 `CommentService`의  리팩토링 작업을 완료해놓았습니다. 확인해보시고 추가적인 의견이 있다면 편하게 말씀주세요 :)
- 만료된 액세스 토큰으로 로그아웃 요청을 보낸 경우에도 로그아웃 성공 처리를 해두었습니다.
- @mingmingmon  이전에 말씀드린 `updateComment` 수정 사항 확인 부탁드릴게요!

➕ **`updateComment` 수정 사항 관련 설명**
 `updateComment`에 `@Transactinal` 을 적용한다면 엔티티를 조회해오고 변경하는 작업이 하나의 트랜잭션에 속하게 됩니다. 영속성 컨텍스트의 변경 감지 기능으로, 트랜잭션 커밋 시 해당 트랜잭션 범위의 변경 사항이 데이터베이스에 반영됩니다. 따라서 별도의 `saveComment`를 호출하지 않아도 `update`된 내용이 데이터베이스에 반영되게 됩니다.
