### PR TITLE
좋아요 관련 API 구현 완료

### DIFF
--- a/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/munecting/api/domain/comment/dao/CommentRepository.java
@@ -19,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.trackId = :trackId AND (:cursorStr IS NULL OR c.createdAt < CAST(:cursorStr AS TIMESTAMP)) ORDER BY c.createdAt DESC")
     Page<Comment> findCommentsByTrackIdWithCursor(
             @Param("trackId") String trackId, @Param("cursorStr") String cursorStr, Pageable pageable);
+
+    int countByTrackId(String musicId);
 }

--- a/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
@@ -74,7 +74,4 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
-    public void deleteCommentsByUserId(Long userId) {
-        commentRepository.deleteByUserId(userId);
-    }
 }

--- a/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
+++ b/src/main/java/com/munecting/api/domain/comment/service/CommentService.java
@@ -28,7 +28,7 @@ public class CommentService {
 
     public Long createComment(CommentRequestDto commentRequestDto) {
         String trackId = commentRequestDto.getTrackId();
-        spotifyService.getTrack(trackId);
+        spotifyService.validateTrackId(trackId);
         Comment comment = Comment.toEntity(commentRequestDto);
         Long id = saveCommentEntity(comment);
         return id;

--- a/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
+++ b/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
@@ -32,4 +32,13 @@ public class LikeController {
         return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), dto);
     }
 
+    @DeleteMapping("/{trackId}/likes")
+    @Operation(summary = "좋아요 취소")
+    public ApiResponse<?> deleteTrackLike (
+            @PathVariable(name = "trackId") String trackId,
+            @UserId Long userId
+    ) {
+        DeleteTrackLikeResponseDto dto = likeService.deleteTrackLike(trackId, userId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
+    }
 }

--- a/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
+++ b/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
@@ -1,14 +1,35 @@
 package com.munecting.api.domain.like.controller;
 
+import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
+import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
+import com.munecting.api.domain.like.service.LikeService;
+import com.munecting.api.global.auth.user.UserId;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/like")
+@RequestMapping("/api/tracks")
 @Tag(name = "like", description = "Like 관련 api")
 public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/{trackId}/likes")
+    @Operation(summary = "좋아요 누르기")
+    public ApiResponse<?> addTrackLike(
+            @PathVariable(name = "trackId") String trackId,
+            @UserId Long userId
+    ) {
+        AddTrackLikeResponseDto dto = likeService.addTrackLike(trackId, userId);
+        return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), dto);
+    }
 
 }

--- a/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
+++ b/src/main/java/com/munecting/api/domain/like/controller/LikeController.java
@@ -2,7 +2,7 @@ package com.munecting.api.domain.like.controller;
 
 import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
 import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
-import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
+import com.munecting.api.domain.like.dto.response.GetLikedTrackListResponseDto;
 import com.munecting.api.domain.like.service.LikeService;
 import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
@@ -11,8 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +28,17 @@ public class LikeController {
     ) {
         AddTrackLikeResponseDto dto = likeService.addTrackLike(trackId, userId);
         return ApiResponse.onSuccess(Status.CREATED.getCode(), Status.CREATED.getMessage(), dto);
+    }
+
+    @GetMapping("/liked")
+    @Operation(summary = "좋아요한 음악 조회")
+    public ApiResponse<?> getLikedTracks (
+            @UserId Long userId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false, defaultValue = "20") int size
+    ) {
+        GetLikedTrackListResponseDto dto = likeService.getLikedTracks(userId, cursor, size);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
     }
 
     @DeleteMapping("/{trackId}/likes")

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -4,4 +4,5 @@ import com.munecting.api.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    int countByTrackId(String trackId);
 }

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -1,7 +1,14 @@
 package com.munecting.api.domain.like.dao;
 
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
 import com.munecting.api.domain.like.entity.Like;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     int countByTrackId(String trackId);
@@ -9,4 +16,10 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserIdAndTrackId(Long userId, String trackId);
 
     void deleteByTrackIdAndUserId(String trackId, Long userId);
+
+    Slice<Like> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+
+    @Query("SELECT l from Like l where l.userId = :userId and l.id < :id")
+    Slice<Like> findByUserId(@Param("userId") Long userId, @Param("id") Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     int countByTrackId(String trackId);
+
+    boolean existsByUserIdAndTrackId(Long userId, String trackId);
 }

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -7,4 +7,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     int countByTrackId(String trackId);
 
     boolean existsByUserIdAndTrackId(Long userId, String trackId);
+
+    void deleteByTrackIdAndUserId(String trackId, Long userId);
 }

--- a/src/main/java/com/munecting/api/domain/like/dto/response/AddTrackLikeResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/like/dto/response/AddTrackLikeResponseDto.java
@@ -1,0 +1,18 @@
+package com.munecting.api.domain.like.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AddTrackLikeResponseDto(
+        String trackId,
+        boolean isLiked,
+        int likeCount
+) {
+    public static AddTrackLikeResponseDto of(String trackId, int likeCount, boolean isLiked) {
+        return AddTrackLikeResponseDto.builder()
+                .trackId(trackId)
+                .likeCount(likeCount)
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/like/dto/response/DeleteTrackLikeResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/like/dto/response/DeleteTrackLikeResponseDto.java
@@ -1,0 +1,18 @@
+package com.munecting.api.domain.like.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteTrackLikeResponseDto(
+        String trackId,
+        boolean isLiked,
+        int likeCount
+) {
+    public static DeleteTrackLikeResponseDto of(String trackId, boolean isLiked, int likeCount) {
+        return DeleteTrackLikeResponseDto.builder()
+                .trackId(trackId)
+                .isLiked(isLiked)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/like/dto/response/GetLikedTrackListResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/like/dto/response/GetLikedTrackListResponseDto.java
@@ -1,0 +1,25 @@
+package com.munecting.api.domain.like.dto.response;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record GetLikedTrackListResponseDto(
+        boolean isEmpty,
+        boolean hasNext,
+        List<GetLikedTrackResponseDto> likedTracks
+){
+    public static GetLikedTrackListResponseDto of(
+            boolean isEmpty,
+            boolean hasNext,
+            List<GetLikedTrackResponseDto> tracks
+    ) {
+        return GetLikedTrackListResponseDto.builder()
+                .isEmpty(isEmpty)
+                .hasNext(hasNext)
+                .likedTracks(tracks)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/like/dto/response/GetLikedTrackResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/like/dto/response/GetLikedTrackResponseDto.java
@@ -1,0 +1,17 @@
+package com.munecting.api.domain.like.dto.response;
+
+import com.wrapper.spotify.model_objects.specification.Image;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetLikedTrackResponseDto(
+        Long likeId,
+        String trackId,
+        String trackTitle,
+        List<LikedTrackArtistResponseDto> artists,
+        String trackPreview,
+        Image[] images
+) {
+}

--- a/src/main/java/com/munecting/api/domain/like/dto/response/LikedTrackArtistResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/like/dto/response/LikedTrackArtistResponseDto.java
@@ -1,0 +1,14 @@
+package com.munecting.api.domain.like.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LikedTrackArtistResponseDto(
+        String artistName
+) {
+    public static LikedTrackArtistResponseDto of(String artistName) {
+        return LikedTrackArtistResponseDto.builder()
+                .artistName(artistName)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/like/entity/Like.java
+++ b/src/main/java/com/munecting/api/domain/like/entity/Like.java
@@ -27,4 +27,10 @@ public class Like extends BaseEntity {
     @NotNull
     private String trackId;
 
+    public static Like toEntity(Long userId, String trackId) {
+        return Like.builder()
+                .userId(userId)
+                .trackId(trackId)
+                .build();
+    }
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -3,15 +3,12 @@ package com.munecting.api.domain.like.service;
 import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
 import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
-import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
 import com.munecting.api.domain.like.entity.Like;
 import com.munecting.api.domain.spotify.service.SpotifyService;
 import com.munecting.api.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,8 +35,22 @@ public class LikeService {
         }
 
         int likeCount = likeRepository.countByTrackId(trackId);
-
         return AddTrackLikeResponseDto.of(trackId,likeCount, isLikedTrack);
+    }
+
+    @Transactional
+    public DeleteTrackLikeResponseDto deleteTrackLike(String trackId, Long userId) {
+        spotifyService.validateTrackId(trackId);
+        userService.validateUserExists(userId);
+
+        boolean isLikedTrack = isTrackLikedByUser(trackId, userId);
+        if (isLikedTrack) {
+            likeRepository.deleteByTrackIdAndUserId(trackId, userId);
+            isLikedTrack = false;
+        }
+
+        int likeCount = likeRepository.countByTrackId(trackId);
+        return DeleteTrackLikeResponseDto.of(trackId, isLikedTrack, likeCount);
     }
 
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -1,7 +1,26 @@
 package com.munecting.api.domain.like.service;
 
+import com.munecting.api.domain.like.dao.LikeRepository;
+import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
+import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
+import com.munecting.api.domain.like.entity.Like;
+import com.munecting.api.domain.spotify.service.SpotifyService;
+import com.munecting.api.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public boolean isTrackLikedByUser(String trackId, Long userId) {
+        return likeRepository.existsByUserIdAndTrackId(userId, trackId);
+    }
+
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -18,9 +18,28 @@ import java.util.List;
 public class LikeService {
 
     private final LikeRepository likeRepository;
+    private final SpotifyService spotifyService;
+    private final UserService userService;
 
     public boolean isTrackLikedByUser(String trackId, Long userId) {
         return likeRepository.existsByUserIdAndTrackId(userId, trackId);
+    }
+
+    @Transactional
+    public AddTrackLikeResponseDto addTrackLike(String trackId, Long userId) {
+        spotifyService.validateTrackId(trackId);
+        userService.validateUserExists(userId);
+
+        boolean isLikedTrack = isTrackLikedByUser(trackId, userId);
+        if (!isLikedTrack) {
+            Like like = Like.toEntity(userId, trackId);
+            likeRepository.save(like);
+            isLikedTrack = true;
+        }
+
+        int likeCount = likeRepository.countByTrackId(trackId);
+
+        return AddTrackLikeResponseDto.of(trackId,likeCount, isLikedTrack);
     }
 
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -84,8 +84,4 @@ public class LikeService {
         return DeleteTrackLikeResponseDto.of(trackId, isLikedTrack, likeCount);
     }
 
-    public void deleteLikesByUserId(Long userId) {
-        likeRepository.deleteByUserId(userId);
-    }
-
 }

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -3,12 +3,21 @@ package com.munecting.api.domain.like.service;
 import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
 import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
+import com.munecting.api.domain.like.dto.response.GetLikedTrackListResponseDto;
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
 import com.munecting.api.domain.like.entity.Like;
 import com.munecting.api.domain.spotify.service.SpotifyService;
 import com.munecting.api.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +45,29 @@ public class LikeService {
 
         int likeCount = likeRepository.countByTrackId(trackId);
         return AddTrackLikeResponseDto.of(trackId,likeCount, isLikedTrack);
+    }
+
+    @Transactional(readOnly = true)
+    public GetLikedTrackListResponseDto getLikedTracks(Long userId, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Like> likes = getLikeSlice(userId, cursor, pageable);
+
+        List<GetLikedTrackResponseDto> likedTracks = likes.stream()
+                .map(like -> {
+                    String trackId = like.getTrackId();
+                    return spotifyService.getTrackForLiked(trackId, like.getId());
+                })
+                .collect(Collectors.toList());
+
+        return GetLikedTrackListResponseDto.of(likes.isEmpty(), likes.hasNext(), likedTracks);
+    }
+
+    private Slice<Like> getLikeSlice(Long userId, Long cursor, Pageable pageable) {
+        if (cursor == null) {
+            return likeRepository.findByUserId(userId, pageable);
+        } else {
+            return likeRepository.findByUserId(userId, cursor, pageable);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -55,7 +55,7 @@ public class LikeService {
         List<GetLikedTrackResponseDto> likedTracks = likes.stream()
                 .map(like -> {
                     String trackId = like.getTrackId();
-                    return spotifyService.getTrackForLiked(trackId, like.getId());
+                    return spotifyService.getLikedTrack(trackId, like.getId());
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/munecting/api/domain/spotify/dto/SpotifyDtoMapper.java
+++ b/src/main/java/com/munecting/api/domain/spotify/dto/SpotifyDtoMapper.java
@@ -1,14 +1,16 @@
 package com.munecting.api.domain.spotify.dto;
 
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
+import com.munecting.api.domain.like.dto.response.LikedTrackArtistResponseDto;
 import com.wrapper.spotify.model_objects.specification.AlbumSimplified;
 import com.wrapper.spotify.model_objects.specification.Artist;
 import com.wrapper.spotify.model_objects.specification.Track;
 import com.wrapper.spotify.model_objects.specification.TrackSimplified;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +36,21 @@ public class SpotifyDtoMapper {
         responseDto.setArtists(artistResponseDtos);
 
         return responseDto;
+    }
+
+
+    public GetLikedTrackResponseDto convertToLikedTrackResponseDto(Track track, Long likeId) {
+        return GetLikedTrackResponseDto.builder()
+                .trackPreview(track.getPreviewUrl())
+                .trackTitle(track.getName())
+                .trackId(track.getId())
+                .images(track.getAlbum().getImages())
+                .artists(Arrays.stream(track.getArtists())
+                        .map(artist ->
+                                LikedTrackArtistResponseDto.of(artist.getName()))
+                        .collect(Collectors.toList()))
+                .likeId(likeId)
+                .build();
     }
 
     public MusicResponseDto convertToTrackResponseDto(TrackSimplified trackSimplified) {

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyApiCall.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyApiCall.java
@@ -1,0 +1,11 @@
+package com.munecting.api.domain.spotify.service;
+
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import org.apache.hc.core5.http.ParseException;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface SpotifyApiCall<T> {
+    T execute() throws IOException, ParseException, SpotifyWebApiException;
+}

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -159,6 +159,7 @@ public class SpotifyService {
 
     }
 
-
-
+    public void validateTrackId(String trackId) {
+        getTrack(trackId);
+    }
 }

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -147,29 +147,26 @@ public class SpotifyService {
     }
 
     public MusicResponseDto getTrack(String trackId) {
-        GetTrackRequest getTrackRequest = spotifyApi.getTrack(trackId)
-                .market(CountryCode.KR)
-                .build();
-
-        try {
-            Track track = getTrackRequest.execute();
-            return spotifyDtoMapper.convertToTrackResponseDto(track);
-        } catch (IOException | ParseException | SpotifyWebApiException ex) {
-            throw new EntityNotFoundException(Status.TRACK_NOT_FOUND);
-        }
-
+        Track track = fetchTrackById(trackId);
+        return spotifyDtoMapper.convertToTrackResponseDto(track);
     }
 
-    public GetLikedTrackResponseDto getTrackForLiked(String trackId, Long likeId) {
+    public GetLikedTrackResponseDto getLikedTrack(String trackId, Long likeId) {
+        Track track = fetchTrackById(trackId);
+        return spotifyDtoMapper.convertToLikedTrackResponseDto(track, likeId);
+    }
+
+    public void validateTrackId(String trackId) {
+        fetchTrackById(trackId);
+    }
+
+    private Track fetchTrackById(String trackId) {
         GetTrackRequest getTrackRequest = spotifyApi.getTrack(trackId)
                 .market(CountryCode.KR)
                 .build();
 
-        return handleSpotifyApiCall(() -> {
-            Track track = getTrackRequest.execute();
-            return spotifyDtoMapper.convertToLikedTrackResponseDto(track, likeId);
-
-        }, Status.TRACK_NOT_FOUND);
+        return handleSpotifyApiCall(
+                getTrackRequest::execute, Status.TRACK_NOT_FOUND);
     }
 
     private <T> T handleSpotifyApiCall(SpotifyApiCall<T> apiCall, Status status) {
@@ -178,9 +175,5 @@ public class SpotifyService {
         } catch (IOException | ParseException | SpotifyWebApiException ex) {
             throw new EntityNotFoundException(status);
         }
-    }
-
-    public void validateTrackId(String trackId) {
-        getTrack(trackId);
     }
 }

--- a/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
+++ b/src/main/java/com/munecting/api/domain/spotify/service/SpotifyService.java
@@ -1,6 +1,7 @@
 package com.munecting.api.domain.spotify.service;
 
 
+import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
 import com.munecting.api.domain.spotify.dto.AlbumResponseDto;
 import com.munecting.api.domain.spotify.dto.ArtistResponseDto;
 import com.munecting.api.domain.spotify.dto.MusicResponseDto;
@@ -157,6 +158,26 @@ public class SpotifyService {
             throw new EntityNotFoundException(Status.TRACK_NOT_FOUND);
         }
 
+    }
+
+    public GetLikedTrackResponseDto getTrackForLiked(String trackId, Long likeId) {
+        GetTrackRequest getTrackRequest = spotifyApi.getTrack(trackId)
+                .market(CountryCode.KR)
+                .build();
+
+        return handleSpotifyApiCall(() -> {
+            Track track = getTrackRequest.execute();
+            return spotifyDtoMapper.convertToLikedTrackResponseDto(track, likeId);
+
+        }, Status.TRACK_NOT_FOUND);
+    }
+
+    private <T> T handleSpotifyApiCall(SpotifyApiCall<T> apiCall, Status status) {
+        try {
+            return apiCall.execute();
+        } catch (IOException | ParseException | SpotifyWebApiException ex) {
+            throw new EntityNotFoundException(status);
+        }
     }
 
     public void validateTrackId(String trackId) {

--- a/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
+++ b/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
@@ -1,0 +1,31 @@
+package com.munecting.api.domain.track.controller;
+
+import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
+import com.munecting.api.domain.track.service.TrackService;
+import com.munecting.api.global.common.dto.response.ApiResponse;
+import com.munecting.api.global.common.dto.response.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tracks")
+@Tag(name = "track", description = "track 관련 api")
+public class TrackController {
+
+    private final TrackService trackService;
+
+    @GetMapping("/{trackId}/details")
+    @Operation(summary = "좋아요와 댓글 개수 조회")
+    public ApiResponse<?> getTrackDetails(
+            @PathVariable(name = "trackId") String musicId
+    ) {
+        GetTrackDetailsResponseDto dto = trackService.getTrackDetails(musicId);
+        return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
+    }
+}

--- a/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
+++ b/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
@@ -1,7 +1,9 @@
 package com.munecting.api.domain.track.controller;
 
+import com.munecting.api.domain.track.dto.response.GetRecentTracksResponseDto;
 import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
 import com.munecting.api.domain.track.service.TrackService;
+import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
 import com.munecting.api.global.common.dto.response.Status;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,17 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/tracks")
-@Tag(name = "track", description = "track 관련 api")
+@Tag(name = "track", description = "track 관련 기타 api")
 public class TrackController {
 
     private final TrackService trackService;
 
     @GetMapping("/{trackId}/details")
-    @Operation(summary = "좋아요와 댓글 개수 조회")
+    @Operation(summary = "좋아요와 댓글 정보 조회")
     public ApiResponse<?> getTrackDetails(
-            @PathVariable(name = "trackId") String musicId
+            @PathVariable(name = "trackId") String trackId,
+            @UserId Long userId
     ) {
-        GetTrackDetailsResponseDto dto = trackService.getTrackDetails(musicId);
+        GetTrackDetailsResponseDto dto = trackService.getTrackDetails(trackId, userId);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), dto);
     }
 }

--- a/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
+++ b/src/main/java/com/munecting/api/domain/track/controller/TrackController.java
@@ -1,6 +1,5 @@
 package com.munecting.api.domain.track.controller;
 
-import com.munecting.api.domain.track.dto.response.GetRecentTracksResponseDto;
 import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
 import com.munecting.api.domain.track.service.TrackService;
 import com.munecting.api.global.auth.user.UserId;

--- a/src/main/java/com/munecting/api/domain/track/dto/response/GetTrackDetailsResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/track/dto/response/GetTrackDetailsResponseDto.java
@@ -1,0 +1,16 @@
+package com.munecting.api.domain.track.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetTrackDetailsResponseDto(
+        int likeCount,
+        int commentCount
+) {
+    public static GetTrackDetailsResponseDto of (int likeCount, int commentCount) {
+        return GetTrackDetailsResponseDto.builder()
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/track/dto/response/GetTrackDetailsResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/track/dto/response/GetTrackDetailsResponseDto.java
@@ -4,11 +4,13 @@ import lombok.Builder;
 
 @Builder
 public record GetTrackDetailsResponseDto(
+        boolean isLiked,
         int likeCount,
         int commentCount
 ) {
-    public static GetTrackDetailsResponseDto of (int likeCount, int commentCount) {
+    public static GetTrackDetailsResponseDto of (boolean isLiked, int likeCount, int commentCount) {
         return GetTrackDetailsResponseDto.builder()
+                .isLiked(isLiked)
                 .likeCount(likeCount)
                 .commentCount(commentCount)
                 .build();

--- a/src/main/java/com/munecting/api/domain/track/service/TrackService.java
+++ b/src/main/java/com/munecting/api/domain/track/service/TrackService.java
@@ -4,7 +4,6 @@ import com.munecting.api.domain.comment.dao.CommentRepository;
 import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.like.service.LikeService;
 import com.munecting.api.domain.spotify.service.SpotifyService;
-import com.munecting.api.domain.track.dto.response.GetRecentTracksResponseDto;
 import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
 import com.munecting.api.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/munecting/api/domain/track/service/TrackService.java
+++ b/src/main/java/com/munecting/api/domain/track/service/TrackService.java
@@ -2,8 +2,11 @@ package com.munecting.api.domain.track.service;
 
 import com.munecting.api.domain.comment.dao.CommentRepository;
 import com.munecting.api.domain.like.dao.LikeRepository;
+import com.munecting.api.domain.like.service.LikeService;
 import com.munecting.api.domain.spotify.service.SpotifyService;
+import com.munecting.api.domain.track.dto.response.GetRecentTracksResponseDto;
 import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
+import com.munecting.api.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,17 +16,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackService {
 
     private final SpotifyService spotifyService;
+    private final UserService userService;
+    private final LikeService likeService;
     private final LikeRepository likeRepository;
     private final CommentRepository commentRepository;
 
     @Transactional(readOnly = true)
-    public GetTrackDetailsResponseDto getTrackDetails(String trackId) {
+    public GetTrackDetailsResponseDto getTrackDetails(String trackId, Long userId) {
         spotifyService.validateTrackId(trackId);
+        userService.validateUserExists(userId);
 
+        boolean isLiked = likeService.isTrackLikedByUser(trackId, userId);
         int likeCount = likeRepository.countByTrackId(trackId);
         int commentCount = commentRepository.countByTrackId(trackId);
 
-        return GetTrackDetailsResponseDto.of(likeCount, commentCount);
+        return GetTrackDetailsResponseDto.of(isLiked, likeCount, commentCount);
     }
 }
 

--- a/src/main/java/com/munecting/api/domain/track/service/TrackService.java
+++ b/src/main/java/com/munecting/api/domain/track/service/TrackService.java
@@ -1,0 +1,29 @@
+package com.munecting.api.domain.track.service;
+
+import com.munecting.api.domain.comment.dao.CommentRepository;
+import com.munecting.api.domain.like.dao.LikeRepository;
+import com.munecting.api.domain.spotify.service.SpotifyService;
+import com.munecting.api.domain.track.dto.response.GetTrackDetailsResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TrackService {
+
+    private final SpotifyService spotifyService;
+    private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public GetTrackDetailsResponseDto getTrackDetails(String trackId) {
+        spotifyService.validateTrackId(trackId);
+
+        int likeCount = likeRepository.countByTrackId(trackId);
+        int commentCount = commentRepository.countByTrackId(trackId);
+
+        return GetTrackDetailsResponseDto.of(likeCount, commentCount);
+    }
+}
+

--- a/src/main/java/com/munecting/api/domain/uploadedMusic/service/MusicService.java
+++ b/src/main/java/com/munecting/api/domain/uploadedMusic/service/MusicService.java
@@ -47,7 +47,4 @@ public class MusicService {
         return uploadedMusicRepository.findUploadedMusicByLocationAndRadius(latitude, longitude, radius);
     }
 
-    public void deleteUploadedMusicsByUserId(Long userId) {
-        uploadedMusicRepository.deleteByUserId(userId);
-    }
 }

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -1,9 +1,13 @@
 package com.munecting.api.domain.user.service;
 
+import com.munecting.api.domain.user.dao.UserRepository;
+import com.munecting.api.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.munecting.api.global.common.dto.response.Status.USER_NOT_FOUND;
 
 @Slf4j
 @Transactional
@@ -11,5 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserService {
 
+    private final UserRepository userRepository;
 
+    public void validateUserExists(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new EntityNotFoundException(USER_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -1,11 +1,10 @@
 package com.munecting.api.domain.user.service;
 
-import com.munecting.api.domain.comment.service.CommentService;
-import com.munecting.api.domain.like.service.LikeService;
-import com.munecting.api.domain.uploadedMusic.service.MusicService;
+import com.munecting.api.domain.comment.dao.CommentRepository;
+import com.munecting.api.domain.like.dao.LikeRepository;
+import com.munecting.api.domain.uploadedMusic.dao.UploadedMusicRepository;
 import com.munecting.api.domain.user.dao.UserRepository;
 import com.munecting.api.domain.user.entity.User;
-import com.munecting.api.global.common.dto.response.Status;
 import com.munecting.api.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,11 +21,11 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    private final CommentService commentService;
+    private final CommentRepository commentRepository;
 
-    private final LikeService likeService;
+    private final LikeRepository likeRepository;
 
-    private final MusicService musicService;
+    private final UploadedMusicRepository uploadedMusicRepository;
 
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
@@ -35,9 +34,9 @@ public class UserService {
     }
 
     private void deleteUserRelatedEntities(Long userId) {
-        commentService.deleteCommentsByUserId(userId);
-        likeService.deleteLikesByUserId(userId);
-        musicService.deleteUploadedMusicsByUserId(userId);
+        commentRepository.deleteByUserId(userId);
+        likeRepository.deleteByUserId(userId);
+        uploadedMusicRepository.deleteByUserId(userId);
     }
   
   

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -40,6 +40,9 @@ public enum Status {
 
     //댓글 오류 응답
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "댓글이 존재하지 않습니다."),
+
+    // User 오류 응답
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 회원입니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 이슈 번호
- close: #29 

## 작업 내용

- 좋아요 누르기 API
- 좋아요 취소 API
- 좋아요 개수, 특정 음악에 대한 유저 좋아요 상태, 댓글 개수와 같이 음악에 대한 기타 정보를 반환하는 API
- 좋아요한 음악 리스트 조회 API (최신순으로 반환, cursor 기반 페이지네이션)

## 스크린샷
> 좋아요 누르기
![image](https://github.com/user-attachments/assets/480f7485-6ff1-42e3-b425-e4836247bd4d)

> 좋아요 취소
![image](https://github.com/user-attachments/assets/5c6522eb-7c09-4deb-9e19-e573413549e8)

> 음악 정보 조회
![image](https://github.com/user-attachments/assets/628ff4b5-7b02-4135-aac6-919a6f4fc814)

> 좋아요한 음악 리스트 조회
![image](https://github.com/user-attachments/assets/0e3dd74b-8270-4bd4-812e-f591668e57ea)

## 확인 요청 사항
- 각 API에 대한 상세한 설명은 노션-백엔드-[API 명세서](https://www.notion.so/599bfe8ebc754db9abd12d4596c7f127?v=74f8aa3339ec4547a664b0aff1552478&pvs=4)에 기술되어있습니다! 
- `spotify API`를 호출하는 과정에 있어 반복되는 예외 처리 구문을 함수형 인터페이스를 활용하여 단순화하였습니다. #31 에서 이를 활용하여 반복되는 구문을 줄여보는건 어떨까요? 이와 관련되어서 더 좋은 방안이 있다면 말씀해주시면 감사하겠습니다.
- `createComment`에서 `spotifyService.getTrack(trackId)`를 작성해준 의도를 분명하게 드러나게 하면 어떨까 싶어, 해당 코드를 감싼 `validateTrackId(trackId)`메소드를 사용하도록 변경해보았습니다. 혹시나 잘못된 변경이거나 다른 의견이 있으시면 편하게 말씀해주세요!

