### PR TITLE
좋아요 추가 기능에 분산락 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	runtimeOnly 'com.h2database:h2'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	//redis
+	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.36.0'
 
 	// Etc
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//mail
-	implementation group: 'jakarta.mail', name: 'jakarta.mail-api', version: '2.1.3'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
-
 	// Spotify
 	implementation 'se.michaelthelin.spotify:spotify-web-api-java:6.5.2'
 

--- a/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
+++ b/src/main/java/com/munecting/api/domain/like/dao/LikeRepository.java
@@ -1,6 +1,5 @@
 package com.munecting.api.domain.like.dao;
 
-import com.munecting.api.domain.like.dto.response.GetLikedTrackResponseDto;
 import com.munecting.api.domain.like.entity.Like;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -8,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 

--- a/src/main/java/com/munecting/api/domain/like/service/LikeService.java
+++ b/src/main/java/com/munecting/api/domain/like/service/LikeService.java
@@ -1,5 +1,6 @@
 package com.munecting.api.domain.like.service;
 
+import com.munecting.api.global.aop.annotation.DistributedLock;
 import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.like.dto.response.AddTrackLikeResponseDto;
 import com.munecting.api.domain.like.dto.response.DeleteTrackLikeResponseDto;
@@ -9,6 +10,7 @@ import com.munecting.api.domain.like.entity.Like;
 import com.munecting.api.domain.spotify.service.SpotifyService;
 import com.munecting.api.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class LikeService {
 
@@ -31,7 +34,7 @@ public class LikeService {
         return likeRepository.existsByUserIdAndTrackId(userId, trackId);
     }
 
-    @Transactional
+    @DistributedLock(key = "#trackId + ':' + #userId" )
     public AddTrackLikeResponseDto addTrackLike(String trackId, Long userId) {
         spotifyService.validateTrackExists(trackId);
         userService.validateUserExists(userId);

--- a/src/main/java/com/munecting/api/global/aop/annotation/DistributedLock.java
+++ b/src/main/java/com/munecting/api/global/aop/annotation/DistributedLock.java
@@ -1,0 +1,34 @@
+package com.munecting.api.global.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * <p> 락을 기다리는 시간 </p>
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * <p> 락 임대 시간 </p>
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 5L;
+}

--- a/src/main/java/com/munecting/api/global/aop/aspect/AopForTransaction.java
+++ b/src/main/java/com/munecting/api/global/aop/aspect/AopForTransaction.java
@@ -1,0 +1,18 @@
+package com.munecting.api.global.aop.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/munecting/api/global/aop/aspect/DistributedLockAop.java
+++ b/src/main/java/com/munecting/api/global/aop/aspect/DistributedLockAop.java
@@ -1,0 +1,94 @@
+package com.munecting.api.global.aop.aspect;
+
+import com.munecting.api.global.util.CustomSpringELParser;
+import com.munecting.api.global.aop.annotation.DistributedLock;
+import com.munecting.api.global.error.exception.DistributedLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import java.lang.reflect.Method;
+
+import static com.munecting.api.global.common.dto.response.Status.DISTRIBUTED_LOCK_ACQUISITION_FAILURE;
+import static com.munecting.api.global.common.dto.response.Status.DISTRIBUTED_LOCK_TEMP_ERROR;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.munecting.api.global.aop.annotation.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+        String key = createKeyFrom(joinPoint, signature, distributedLock);
+        RLock rLock = redissonClient.getLock(key);
+        try {
+            checkAvailableLock(distributedLock, rLock, key, method);
+            return aopForTransaction.proceed(joinPoint);
+        } finally {
+            releaseLockSafely(method, key, rLock);
+        }
+    }
+
+    private String createKeyFrom(ProceedingJoinPoint joinPoint, MethodSignature signature, DistributedLock distributedLock) {
+        return REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+    }
+
+    private void checkAvailableLock(DistributedLock distributedLock, RLock rLock, String key, Method method) {
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                logAcquireLockFailure(method, key);
+                throw new DistributedLockException(DISTRIBUTED_LOCK_ACQUISITION_FAILURE);
+            }
+        } catch (InterruptedException e) {
+            logThreadInterruption(method, key, e);
+            throw new DistributedLockException(DISTRIBUTED_LOCK_TEMP_ERROR);
+        }
+    }
+
+    private void logAcquireLockFailure(Method method, String key) {
+        log.warn("Failed to acquire lock for method: {} with key: {}", method.getName(), key);
+    }
+
+    private void logThreadInterruption(Method method, String key, InterruptedException e) {
+        log.warn("Thread interrupted while attempting to acquire lock for method: {} with key: {}", method.getName(), key, e);
+    }
+
+    private void releaseLockSafely(Method method, String key, RLock rLock) {
+        try {
+            releaseLock(method, key, rLock);
+        } catch (IllegalMonitorStateException e) {
+            logReleaseLockFailure(method, key, e);
+        }
+    }
+
+    private void releaseLock(Method method, String key, RLock rLock) {
+        if (rLock.isHeldByCurrentThread()) {
+            rLock.unlock();
+            log.info("Lock released for method: {} with key: {}", method.getName(), key);
+        }
+    }
+
+    private void logReleaseLockFailure(Method method, String key, IllegalMonitorStateException e) {
+        log.warn("Failed to release lock for method: {} with key: {}. Lock may have already been released.", method.getName(), key, e);
+    }
+}

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -42,7 +42,11 @@ public enum Status {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404", "댓글이 존재하지 않습니다."),
 
     // User 오류 응답
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 회원입니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "존재하지 않는 회원입니다."),
+
+    // 분산락 오류 응답
+    DISTRIBUTED_LOCK_ACQUISITION_FAILURE(HttpStatus.CONFLICT, "LOCK409", "잠시 후에 시도해주세요."),
+    DISTRIBUTED_LOCK_TEMP_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "LOCK500", "일시적인 오류가 발생하였습니다. 잠시 후에 시도해주세요"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/config/RedissonConfig.java
+++ b/src/main/java/com/munecting/api/global/config/RedissonConfig.java
@@ -1,0 +1,32 @@
+package com.munecting.api.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private String redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = createRedissonConfig();
+        return Redisson.create(config);
+    }
+
+    private Config createRedissonConfig() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return config;
+    }
+}

--- a/src/main/java/com/munecting/api/global/error/exception/DistributedLockException.java
+++ b/src/main/java/com/munecting/api/global/error/exception/DistributedLockException.java
@@ -1,0 +1,16 @@
+package com.munecting.api.global.error.exception;
+
+import com.munecting.api.global.common.dto.response.Status;
+
+import static com.munecting.api.global.common.dto.response.Status.BAD_REQUEST;
+
+public class DistributedLockException extends GeneralException{
+
+    public DistributedLockException() {
+        super(BAD_REQUEST);
+    }
+
+    public DistributedLockException(Status errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/munecting/api/global/util/CustomSpringELParser.java
+++ b/src/main/java/com/munecting/api/global/util/CustomSpringELParser.java
@@ -1,0 +1,22 @@
+package com.munecting.api.global.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomSpringELParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/test/java/com/munecting/api/MunectingServerApplicationTests.java
+++ b/src/test/java/com/munecting/api/MunectingServerApplicationTests.java
@@ -2,8 +2,10 @@ package com.munecting.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MunectingServerApplicationTests {
 
 	@Test

--- a/src/test/java/com/munecting/api/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/munecting/api/domain/like/service/LikeServiceTest.java
@@ -1,0 +1,82 @@
+package com.munecting.api.domain.like.service;
+
+import com.munecting.api.domain.like.dao.LikeRepository;
+import com.munecting.api.domain.user.constant.Role;
+import com.munecting.api.domain.user.constant.SocialType;
+import com.munecting.api.domain.user.dao.UserRepository;
+import com.munecting.api.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class LikeServiceTest {
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private LikeService likeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final int NUMBER_OF_THREAD = 50;
+
+    @BeforeEach
+    @Transactional
+    void init() {
+        long userId = new AtomicLong(1).get();
+        System.out.println("userId:" + userId);
+
+        userRepository.save(
+                User.builder()
+                        .id(userId)
+                        .role(Role.USER)
+                        .socialType(SocialType.GOOGLE)
+                        .socialId("testSocialId")
+                        .build()
+        );
+    }
+
+    @Test
+    void 멀티_스레드_환경에서_동일한_유저가_좋아요를_여러_번_눌러도_한_번만_증가한다() throws InterruptedException {
+
+        // given
+        long userId = new AtomicLong(1).get();
+        final String trackId = "2VdSktBqFfkW7y6q5Ik4Z4";
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREAD);
+        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_THREAD);
+
+        // when
+        for (int i = 0; i < NUMBER_OF_THREAD; i++) {
+            executorService.execute(
+                    () -> {
+                        try {
+                            likeService.addTrackLike(trackId, userId);
+                        } catch (Throwable e) {
+                            e.printStackTrace();
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        int actualTrackCount = likeRepository.countByTrackId(trackId);
+        assertEquals(1, actualTrackCount);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,100 @@
+server:
+  port: ${SERVER_PORT}
+
+spring :
+  config:
+    activate:
+      on-profile: "test"
+
+  application:
+    name: munectingV4
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+
+    hibernate:
+      ddl-auto: create
+
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true
+        format_sql: true
+
+  # H2 Database 설정
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=PostgreSQL # H2 DB 연결 주소 (In-Memory Mode)
+    #url: 'jdbc:h2:~/test'    # H2 DB 연결 주소 (Embedded Mode)
+    username: ${DATASOURCE_USERNAME:sa}
+    password: ${DATASOURCE_PASSWORD}
+
+  # H2 Console 설정
+  h2:
+    console: # H2 DB를 웹에서 관리할 수 있는 기능
+      enabled: true           # H2 Console 사용 여부
+      path: /h2-console       # H2 Console 접속 주소
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+  #      password: 1234
+  mail:
+    debug: true
+    host: smtp.naver.com
+    port: 465
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            enable: true
+
+  security:
+    cors:
+      allowed-origins: ${CORS_ALLOWED_ORIGINS:*}
+      allowed-methods: ${CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE}
+      allowed-headers: ${CORS_ALLOWED_HEADERS:*}
+      allow-credentials: ${CORS_ALLOW_CREDENTIALS:true}
+      path-pattern: "/**"
+
+    auth:
+      header: ${AUTH_HEADER:Authorization}
+      prefix: ${AUTH_PREFIX:Bearer }
+
+    oauth:
+      kakao:
+        public-key-info: https://kauth.kakao.com/.well-known/jwks.json
+        issuer: https://kauth.kakao.com
+        audience: ${KAKAO_APP_ID}}
+      apple:
+        public-key-url: https://appleid.apple.com/auth/keys
+        issuer: https://appleid.apple.com
+        audience: ${APPLE_APP_ID}
+      google:
+        client-id: ${GOOGLE_CLIENT_ID}
+
+naver:
+  id: ${MAIL_USERNAME}
+  password: ${MAIL_PASSWORD}
+
+spotify:
+  client-id: ${CLIENT_ID}
+  client-secret: ${CLIENT_SECRET}
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access:
+    expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh:
+    expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
+
+kakao-map:
+  api-key: ${KAKAO_MAP_API_KEY}


### PR DESCRIPTION
## 이슈 번호
- close : #43 

## 작업 내용
 같은 유저가 `좋아요` 버튼을 여러 번 클릭하였을 때, 동시성 문제가 발생할 수 있다고 판단하였습니다. 따라서 다음과 같은 테스트 코드를 작성하여 기존의 `API`를 테스트 하였습니다.
```
    @Test
    void 멀티_스레드_환경에서_동일한_유저가_좋아요를_여러_번_눌러도_한_번만_증가한다() throws InterruptedException {

        // given
        long userId = new AtomicLong(1).get();
        final String trackId = "2VdSktBqFfkW7y6q5Ik4Z4";

        final ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREAD);
        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_THREAD);

        // when
        for (int i = 0; i < NUMBER_OF_THREAD; i++) {
            executorService.execute(
                    () -> {
                        try {
                            likeService.addTrackLike(trackId, userId);
                        } catch (Throwable e) {
                            e.printStackTrace();
                        } finally {
                            latch.countDown();
                        }
                    });
        }
        latch.await();
        executorService.shutdown();

        // then
        int actualTrackCount = likeRepository.countByTrackId(trackId);
        assertEquals(1, actualTrackCount);
    }
```
![image](https://github.com/user-attachments/assets/28691c5e-c509-4d69-83a3-e2bd732707dd)
테스트 결과 `좋아요` 가 같은 `track`에 9번 추가되었으므로, 동시성 문제를 고려하지 않은 기존의 `좋아요 추가 API`에는 문제가 있음을 인지하였습니다.

현재 서비스는 `blue-green` 배포가 예정되어 있기 때문에, 일반적인 비관적락이 아닌 분산락을 선택하였습니다. 따라서 분산락을 `좋아요 추가 API`에 적용하여 동시성 문제를 방지하였습니다.
![image](https://github.com/user-attachments/assets/8bcd42c3-ab0b-44d5-828c-673949671abf)

