### PR TITLE
프로필 업데이트 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	//aws
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
 	// Etc
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/munecting/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/UserController.java
@@ -30,6 +30,7 @@ public class UserController {
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), userId);
     }
 
+    //TODO: 엔드포인트에 userId 노출 제거
     @DeleteMapping("/{userId}")
     @Operation(summary = "회원 탈퇴")
     public ApiResponse<?> deleteUser(

--- a/src/main/java/com/munecting/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/UserController.java
@@ -1,15 +1,20 @@
 package com.munecting.api.domain.user.controller;
 
 
+import com.munecting.api.domain.user.dto.request.UpdateProfileRequestDto;
+import com.munecting.api.domain.user.dto.response.UpdateProfileResponseDto;
 import com.munecting.api.domain.user.service.UserService;
 import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
 import com.munecting.api.global.common.dto.response.Status;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,5 +43,23 @@ public class UserController {
     ) {
         userService.deleteUser(userId);
         return ApiResponse.onSuccess(Status.OK.getCode(), Status.OK.getMessage(), null);
+    }
+
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 업데이트")
+    public ApiResponse<?> updateProfile(
+            @UserId Long userId,
+
+            @Schema(description = "새로운 프로필 이미지 파일", nullable = true, type = "string", format = "binary")
+            @RequestPart(value = "profileImage", required = false)
+            MultipartFile profileImage,
+
+            @Schema(description = "새로운 닉네임", nullable = true)
+            @RequestPart(value = "nickname", required = false)
+            String nickname
+    ){
+        UpdateProfileRequestDto requestDto = new UpdateProfileRequestDto(nickname, profileImage);
+        UpdateProfileResponseDto responseDto = userService.updateProfile(userId, requestDto);
+        return ApiResponse.ok(responseDto);
     }
 }

--- a/src/main/java/com/munecting/api/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/munecting/api/domain/user/dao/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findBySocialId(String sub);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/munecting/api/domain/user/dao/UuidRepository.java
+++ b/src/main/java/com/munecting/api/domain/user/dao/UuidRepository.java
@@ -1,0 +1,13 @@
+package com.munecting.api.domain.user.dao;
+
+import com.munecting.api.domain.user.entity.Uuid;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+
+    Optional<Uuid> findByUserId(Long userId);
+}

--- a/src/main/java/com/munecting/api/domain/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/request/UpdateProfileRequestDto.java
@@ -1,0 +1,9 @@
+package com.munecting.api.domain.user.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdateProfileRequestDto(
+        String nickname,
+        MultipartFile profileImage
+) {
+}

--- a/src/main/java/com/munecting/api/domain/user/dto/response/UpdateProfileResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/response/UpdateProfileResponseDto.java
@@ -1,0 +1,17 @@
+package com.munecting.api.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateProfileResponseDto(
+        String nickname,
+        String imageUrl
+) {
+
+    public static UpdateProfileResponseDto of(String nickname, String imgUrl) {
+        return UpdateProfileResponseDto.builder()
+                .nickname(nickname)
+                .imageUrl(imgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/user/entity/User.java
+++ b/src/main/java/com/munecting/api/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import com.munecting.api.domain.user.constant.Role;
 import com.munecting.api.domain.user.constant.SocialType;
 import com.munecting.api.global.common.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.*;
@@ -23,7 +24,7 @@ public class User extends BaseEntity {
     @NotNull
     private String socialId;
 
-    @Column(nullable = true)
+    @NotBlank
     private String nickname;
 
     @Column(nullable = true)

--- a/src/main/java/com/munecting/api/domain/user/entity/User.java
+++ b/src/main/java/com/munecting/api/domain/user/entity/User.java
@@ -36,4 +36,16 @@ public class User extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
+
+    public String updateNickname(String nickname) {
+        this.nickname = nickname;
+
+        return this.nickname;
+    }
+
+    public String updateProfileImageUrl(String imgUrl) {
+        this.profileImageUrl = imgUrl;
+
+        return this.profileImageUrl;
+    }
 }

--- a/src/main/java/com/munecting/api/domain/user/entity/Uuid.java
+++ b/src/main/java/com/munecting/api/domain/user/entity/Uuid.java
@@ -1,0 +1,31 @@
+package com.munecting.api.domain.user.entity;
+
+import com.munecting.api.global.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Uuid extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uuid;
+
+    private Long userId;
+
+    public static Uuid toEntity(Long userId) {
+        return Uuid.builder()
+                .uuid(UUID.randomUUID().toString())
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/user/service/AuthService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/AuthService.java
@@ -88,6 +88,7 @@ public class AuthService {
         return issueTokensForUser(user);
     }
 
+    //TODO: 이메일 제거, 닉네임 자체 생성
     private User createUser(String socialId, String email, SocialType socialType) {
         User newUser = User.builder()
                 .socialId(socialId)

--- a/src/main/java/com/munecting/api/domain/user/service/UserProfileImageService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserProfileImageService.java
@@ -1,0 +1,67 @@
+package com.munecting.api.domain.user.service;
+
+import com.munecting.api.domain.user.entity.User;
+import com.munecting.api.domain.user.entity.Uuid;
+import com.munecting.api.global.aws.s3.AmazonS3Manager;
+import com.munecting.api.global.error.exception.InvalidValueException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
+
+import static com.munecting.api.global.common.dto.response.Status.BAD_REQUEST;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileImageService {
+
+    private final UuidService uuidService;
+    private final AmazonS3Manager s3Manager;
+
+    private static final long MAX_FILE_SIZE = 3 * 1024 * 1024; // 3MB
+    private static final String OVER_FILE_SIZE_ERROR_MESSAGE = "업로드 가능한 파일 사이즈는 최대 3MB입니다.";
+
+    public String updateImage(User user, MultipartFile imgFile) {
+        if (Objects.isNull(imgFile)) {
+            return getImageUrl(user);
+        }
+
+        if (user.getProfileImageUrl() != null) {
+            deleteOldImage(user);
+        }
+
+        String imageUrl = uploadNewImage(user.getId(), imgFile);
+        return user.updateProfileImageUrl(imageUrl);
+    }
+
+    private String getImageUrl(User user) {
+        if (user.getProfileImageUrl() == null) {
+            // 프론트엔드 측 기본 이미지 사용
+            return null;
+        }
+
+        return user.getProfileImageUrl();
+    }
+
+    private void deleteOldImage(User user) {
+        Uuid uuid = uuidService.findByUserId(user.getId());
+        String presentKeyName = s3Manager.generateProfileImageKeyName(uuid);
+        s3Manager.deleteFile(presentKeyName);
+        uuidService.delete(uuid);
+    }
+
+    private String uploadNewImage(Long userId, MultipartFile image) {
+        validateImageSize(image);
+        Uuid uuid = uuidService.createUuid(userId);
+        String keyName = s3Manager.generateProfileImageKeyName(uuid);
+
+        return s3Manager.uploadFile(keyName, image);
+    }
+
+    private void validateImageSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new InvalidValueException(BAD_REQUEST, OVER_FILE_SIZE_ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -74,11 +74,11 @@ public class UserService {
             return user.getNickname();
         }
 
-        validateNickname(nickname);
+        validateNickname(user, nickname);
         return user.updateNickname(nickname);
     }
 
-    private void validateNickname(String nickname) {
+    private void validateNickname(User existingUser, String nickname) {
         if (nickname.length() < MIN_LENGTH || nickname.length() > MAX_LENGTH) {
             throw new InvalidValueException(Status.BAD_REQUEST, NICKNAME_LENGTH_ERROR_MESSAGE);
         }
@@ -88,7 +88,8 @@ public class UserService {
         }
 
         // 중복 검사
-        if (userRepository.existsByNickname(nickname)) {
+        if (!existingUser.getNickname().equals(nickname)
+                && userRepository.existsByNickname(nickname)) {
             throw new InvalidValueException(Status.CONFLICT, NICKNAME_DUPLICATED_ERROR_MESSAGE);
         }
     }

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -4,12 +4,18 @@ import com.munecting.api.domain.comment.dao.CommentRepository;
 import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.uploadedMusic.dao.UploadedMusicRepository;
 import com.munecting.api.domain.user.dao.UserRepository;
+import com.munecting.api.domain.user.dto.request.UpdateProfileRequestDto;
+import com.munecting.api.domain.user.dto.response.UpdateProfileResponseDto;
 import com.munecting.api.domain.user.entity.User;
+import com.munecting.api.global.common.dto.response.Status;
 import com.munecting.api.global.error.exception.EntityNotFoundException;
+import com.munecting.api.global.error.exception.InvalidValueException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.munecting.api.global.common.dto.response.Status.USER_NOT_FOUND;
 
@@ -22,6 +28,17 @@ public class UserService {
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
     private final UploadedMusicRepository uploadedMusicRepository;
+    private final UserProfileImageService userProfileImageService;
+
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 15;
+
+    private static final String NAME_VALUE_RULES = "^[a-zA-Z0-9가-힣]+$";
+
+    private static final String NICKNAME_LENGTH_ERROR_MESSAGE = "닉네임은 2-15자 사이여야 합니다.";
+    private static final String NICKNAME_WRONG_VALUE_ERROR_MESSAGE = "닉네임은 한글, 영문, 숫자만 포함할 수 있습니다.";
+    private static final String NICKNAME_DUPLICATED_ERROR_MESSAGE = "이미 사용 중인 닉네임입니다.";
+
 
     @Transactional
     public void deleteUser(Long userId) {
@@ -41,5 +58,42 @@ public class UserService {
         if (!userRepository.existsById(userId)) {
             throw new EntityNotFoundException(USER_NOT_FOUND);
         }
+    }
+
+    @Transactional
+    public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto requestDto) {
+        User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
+        String nickname = updateNickname(user, requestDto.nickname());
+        String profileImageUrl = updateProfileImage(user, requestDto.profileImage());
+
+        return UpdateProfileResponseDto.of(nickname, profileImageUrl);
+    }
+
+    private String updateNickname(User user, String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            return user.getNickname();
+        }
+
+        validateNickname(nickname);
+        return user.updateNickname(nickname);
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname.length() < MIN_LENGTH || nickname.length() > MAX_LENGTH) {
+            throw new InvalidValueException(Status.BAD_REQUEST, NICKNAME_LENGTH_ERROR_MESSAGE);
+        }
+
+        if (!nickname.matches(NAME_VALUE_RULES)) {
+            throw new InvalidValueException(Status.BAD_REQUEST, NICKNAME_WRONG_VALUE_ERROR_MESSAGE);
+        }
+
+        // 중복 검사
+        if (userRepository.existsByNickname(nickname)) {
+            throw new InvalidValueException(Status.CONFLICT, NICKNAME_DUPLICATED_ERROR_MESSAGE);
+        }
+    }
+
+    private String updateProfileImage(User user, MultipartFile imgFile) {
+        return userProfileImageService.updateImage(user, imgFile);
     }
 }

--- a/src/main/java/com/munecting/api/domain/user/service/UuidService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UuidService.java
@@ -1,0 +1,33 @@
+package com.munecting.api.domain.user.service;
+
+import com.munecting.api.domain.user.entity.Uuid;
+import com.munecting.api.domain.user.dao.UuidRepository;
+import com.munecting.api.global.error.exception.InternalServerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UuidService {
+
+    private final UuidRepository uuidRepository;
+
+    public Uuid createUuid(Long userId) {
+        Uuid uuid = Uuid.toEntity(userId);
+
+        return uuidRepository.save(uuid);
+    }
+
+    public Uuid findByUserId(Long userId) {
+        return uuidRepository.findByUserId(userId).orElseThrow(()-> {
+            log.warn("userId {}과 매핑된 UUID 객체가 존재하지 않습니다.",userId);
+            throw new InternalServerException();
+        });
+    }
+
+    public void delete(Uuid uuid) {
+        uuidRepository.delete(uuid);
+    }
+}

--- a/src/main/java/com/munecting/api/global/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/munecting/api/global/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,66 @@
+package com.munecting.api.global.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.munecting.api.domain.user.entity.Uuid;
+import com.munecting.api.global.config.AmazonConfig;
+import com.munecting.api.global.error.exception.InternalServerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static com.munecting.api.global.common.dto.response.Status.AWS_S3_UPLOAD_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    public String generateProfileImageKeyName(Uuid uuid) {
+        return amazonConfig.getProfileImagePath() + '/' + uuid.getUuid();
+    }
+
+    public String uploadFile(String keyName, MultipartFile file){
+        upload(keyName, file);
+        return getFileUrl(keyName);
+    }
+
+    private void upload(String keyName, MultipartFile file) {
+        try {
+            ObjectMetadata metadata = createMetadata(file);
+            PutObjectRequest request = createPutObjectRequest(keyName, file, metadata);
+            amazonS3.putObject(request);
+
+        } catch (IOException e) {
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+            throw new InternalServerException(AWS_S3_UPLOAD_ERROR);
+        }
+    }
+
+    private ObjectMetadata createMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType("image/jpeg");
+        return metadata;
+    }
+
+    private PutObjectRequest createPutObjectRequest(String keyName, MultipartFile file, ObjectMetadata metadata) throws IOException {
+        return new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata);
+    }
+
+    private String getFileUrl(String keyName) {
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public void deleteFile(String keyName) {
+        amazonS3.deleteObject(amazonConfig.getBucket(), keyName);
+    }
+}

--- a/src/main/java/com/munecting/api/global/common/dto/response/Status.java
+++ b/src/main/java/com/munecting/api/global/common/dto/response/Status.java
@@ -47,6 +47,9 @@ public enum Status {
     // 분산락 오류 응답
     DISTRIBUTED_LOCK_ACQUISITION_FAILURE(HttpStatus.CONFLICT, "LOCK409", "잠시 후에 시도해주세요."),
     DISTRIBUTED_LOCK_TEMP_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "LOCK500", "일시적인 오류가 발생하였습니다. 잠시 후에 시도해주세요"),
+
+    // AWS 오류 응답
+    AWS_S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500", "이미지 업로드에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/munecting/api/global/config/AmazonConfig.java
+++ b/src/main/java/com/munecting/api/global/config/AmazonConfig.java
@@ -1,0 +1,54 @@
+package com.munecting.api.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.path.profile-image}")
+    private String profileImagePath;
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+}

--- a/src/main/java/com/munecting/api/global/config/CorsConfig.java
+++ b/src/main/java/com/munecting/api/global/config/CorsConfig.java
@@ -31,7 +31,7 @@ public class CorsConfig {
     public CorsFilter corsFilter() {
 
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(corsAllowedOrigins));
+        config.setAllowedOriginPatterns(List.of(corsAllowedOrigins));
         config.setAllowedMethods(List.of(corsAllowedMethods));
         config.setAllowedHeaders(List.of(corsAllowedHeaders));
         config.setExposedHeaders(List.of(authHeader));
@@ -41,6 +41,5 @@ public class CorsConfig {
         source.registerCorsConfiguration(corsPathPattern, config);
 
         return new CorsFilter(source);
-
     }
 }

--- a/src/main/java/com/munecting/api/global/error/exception/InternalServerException.java
+++ b/src/main/java/com/munecting/api/global/error/exception/InternalServerException.java
@@ -13,4 +13,8 @@ public class InternalServerException extends GeneralException{
     public InternalServerException(String message) {
         super(message, INTERNAL_SERVER_ERROR);
     }
+
+    public InternalServerException(Status status) {
+        super(status);
+    }
 }

--- a/src/main/java/com/munecting/api/global/error/exception/InvalidValueException.java
+++ b/src/main/java/com/munecting/api/global/error/exception/InvalidValueException.java
@@ -2,13 +2,19 @@ package com.munecting.api.global.error.exception;
 
 import com.munecting.api.global.common.dto.response.Status;
 
+import static com.munecting.api.global.common.dto.response.Status.BAD_REQUEST;
+
 public class InvalidValueException extends GeneralException {
 
     public InvalidValueException() {
-        super(Status.BAD_REQUEST);
+        super(BAD_REQUEST);
     }
 
     public InvalidValueException(Status errorStatus) {
         super(errorStatus);
+    }
+
+    public InvalidValueException(Status errorStatus, String message) {
+        super(message, errorStatus);
     }
 }

--- a/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
@@ -13,11 +13,14 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 
 @RestControllerAdvice
@@ -43,7 +46,7 @@ public class GlobalExceptionHandler {
                 });
 
         ApiResponse<Map<String, String>> response = ApiResponse.onFailure(Status.BAD_REQUEST.getCode(), Status.BAD_REQUEST.getMessage(), errors);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 
     /**
@@ -55,8 +58,8 @@ public class GlobalExceptionHandler {
     ) {
         log.warn(">>> handle: MissingServletRequestParameterException", e);
 
-        ApiResponse<Object> response = ApiResponse.onFailure(HttpStatus.BAD_REQUEST.toString(), e.getMessage(), null);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        ApiResponse<Object> response = ApiResponse.onFailure(BAD_REQUEST.toString(), e.getMessage(), null);
+        return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 
     /**
@@ -83,6 +86,17 @@ public class GlobalExceptionHandler {
 
         ApiResponse<Object> response = ApiResponse.onFailure(HttpStatus.NOT_FOUND.toString(), e.getMessage(), null);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    /**
+     * 업로드 최대 용량을 초과했을 경우
+     */
+    @ExceptionHandler({MaxUploadSizeExceededException.class})
+    protected ResponseEntity<ApiResponse<?>> handleMultipartException(MaxUploadSizeExceededException e) {
+        log.error(">> handle: MaxUploadSizeExceededException {}", e.getMessage());
+
+        ApiResponse<Object> response = ApiResponse.onFailure(BAD_REQUEST.toString(), e.getMessage(), null);
+        return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 
     /**

--- a/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.munecting.api.global.common.dto.response.ApiResponse;
 import com.munecting.api.global.common.dto.response.Body;
 import com.munecting.api.global.common.dto.response.Status;
 import com.munecting.api.global.error.exception.GeneralException;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -47,6 +48,28 @@ public class GlobalExceptionHandler {
 
         ApiResponse<Map<String, String>> response = ApiResponse.onFailure(Status.BAD_REQUEST.getCode(), Status.BAD_REQUEST.getMessage(), errors);
         return ResponseEntity.status(BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
+        log.error(">>> handle: ConstraintViolationException | {}", e.getMessage());
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getConstraintViolations().forEach(violation -> {
+            // PropertyPath를 문자열로 변환
+            String fieldName = violation.getPropertyPath().toString();
+            // 마지막 점 이후의 문자열을 추출, 점이 없으면 전체 문자열을 반환
+            String lastFieldName = fieldName.contains(".") ?
+                    fieldName.substring(fieldName.lastIndexOf('.') + 1) : fieldName;
+
+            String errorMessage = Optional.ofNullable(violation.getMessage()).orElse("");
+            errors.merge(lastFieldName, errorMessage,
+                    (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
+
+        ApiResponse<Map<String, String>> response = ApiResponse.onFailure(Status.BAD_REQUEST.getCode(), Status.BAD_REQUEST.getMessage(), errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,12 @@ spring :
       google:
         client-id: ${GOOGLE_CLIENT_ID}
 
+  servlet:
+    multipart:
+      maxFileSize: 3MB # 파일 하나의 최대 크기
+      maxRequestSize: 10MB  # 한 번에 최대 업로드 가능 용량
+      resolve-lazily: true
+
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,6 @@ spring :
       allowed-origins: ${CORS_ALLOWED_ORIGINS:*}
       allowed-methods: ${CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE}
       allowed-headers: ${CORS_ALLOWED_HEADERS:*}
-      allow-credentials: ${CORS_ALLOW_CREDENTIALS:true}
       path-pattern: "/**"
 
     auth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,20 @@ spring :
         client-id: ${GOOGLE_CLIENT_ID}
 
 
+cloud:
+  aws:
+    s3:
+      bucket: munecting
+      path:
+        profile-image: profileImage
+
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_S3_ACCESS_KEY_ID}
+      secretKey: ${AWS_S3_SECRET_ACCESS_KEY}
 
 spotify:
   client-id: ${CLIENT_ID}


### PR DESCRIPTION
## 📄 PR 요약
사용자 프로필 정보인 닉네임과 프로필 이미지를 업데이트하는 API를 구현하였습니다.

## 📋 관련 이슈
- close: #52

## 🛠️ 변경 사항 설명
- `AWS S3`에 프로필 이미지를 저장합니다. 이에 필요한 `AWS S3` 설정을 완료하였습니다.
-  `Uuid Entity`가 새로 작성되었으며, `User nickname` 필드를 `nullable`에서 `notBlank`로 변경하였습니다.
- **프로필 이미지**와 **닉네임**은 선택적으로 업데이트될 수 있습니다. 따라서 `request`에 이미지 또는 닉네임이 포함되어 있을 경우에만 각 리소스를 업데이트합니다.
    - 이미지 업데이트를 요청할 경우, 기존 이미지는 삭제됩니다. 
    - 업로드 가능한 이미지 최대 크기는 **3MB**로 설정하였습니다.
    - 닉네임에는 **한글, 영어, 숫자**만 저장가능하며 최대 **15글자**로 제한하였습니다.
    - **중복된** 닉네임 설정은 불가능합니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/fcf6dca8-0ca6-4ef1-9d1a-3969d75b3125)
![image](https://github.com/user-attachments/assets/ae37d41d-27ad-4818-8e98-40a152587357)



## 확인 요청 사항
-  `env` 파일 내용이 업데이트 되었으니, 새로 업데이트된 노션- 보안사항의 `env` 파일을 사용하시길 바랍니다.
- DB 테이블이 변경되었으므로 DB 접속 시 새로고침 후 이용해주세요!