### PR TITLE
유저 프로필 조회 API 구현 완료

### DIFF
--- a/src/main/java/com/munecting/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.munecting.api.domain.user.controller;
 
 
 import com.munecting.api.domain.user.dto.request.UpdateProfileRequestDto;
+import com.munecting.api.domain.user.dto.response.GetProfileResponseDto;
 import com.munecting.api.domain.user.dto.response.UpdateProfileResponseDto;
 import com.munecting.api.domain.user.service.UserService;
 import com.munecting.api.global.auth.user.UserId;
@@ -57,9 +58,18 @@ public class UserController {
             @Schema(description = "새로운 닉네임", nullable = true)
             @RequestPart(value = "nickname", required = false)
             String nickname
-    ){
+    ) {
         UpdateProfileRequestDto requestDto = new UpdateProfileRequestDto(nickname, profileImage);
         UpdateProfileResponseDto responseDto = userService.updateProfile(userId, requestDto);
+        return ApiResponse.ok(responseDto);
+    }
+
+    @GetMapping("/profile")
+    @Operation(summary = "프로필 조회")
+    public ApiResponse<?> getProfile(
+            @UserId Long userId
+    ) {
+        GetProfileResponseDto responseDto = userService.getProfile(userId);
         return ApiResponse.ok(responseDto);
     }
 }

--- a/src/main/java/com/munecting/api/domain/user/dto/response/GetProfileResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/response/GetProfileResponseDto.java
@@ -1,0 +1,17 @@
+package com.munecting.api.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetProfileResponseDto(
+        String profileImage,
+        String nickname
+) {
+
+    public static GetProfileResponseDto of(String profileImageUrl, String nickname) {
+        return GetProfileResponseDto.builder()
+                .profileImage(profileImageUrl)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/munecting/api/domain/user/service/UserService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/UserService.java
@@ -5,8 +5,8 @@ import com.munecting.api.domain.like.dao.LikeRepository;
 import com.munecting.api.domain.uploadedMusic.dao.UploadedMusicRepository;
 import com.munecting.api.domain.user.dao.UserRepository;
 import com.munecting.api.domain.user.dto.request.UpdateProfileRequestDto;
+import com.munecting.api.domain.user.dto.response.GetProfileResponseDto;
 import com.munecting.api.domain.user.dto.response.UpdateProfileResponseDto;
-import com.munecting.api.domain.user.dto.response.UserResponseDto;
 import com.munecting.api.domain.user.entity.User;
 import com.munecting.api.global.common.dto.response.Status;
 import com.munecting.api.global.error.exception.EntityNotFoundException;
@@ -101,5 +101,11 @@ public class UserService {
 
     private String updateProfileImage(User user, MultipartFile imgFile) {
         return userProfileImageService.updateImage(user, imgFile);
+    }
+
+    @Transactional(readOnly = true)
+    public GetProfileResponseDto getProfile(Long userId) {
+        User user = findUserByIdOrThrow(userId);
+        return GetProfileResponseDto.of(user.getProfileImageUrl(), user.getNickname());
     }
 }


### PR DESCRIPTION
## 📄 PR 요약
사용자 프로필 정보인 **닉네임**과 **프로필 이미지**를 조회하는 API를 구현하였습니다.

## 📋 관련 이슈
- close: #50

## 🛠️ 변경 사항 설명
사용자 프로필 정보를 조회하여 반환합니다. 이때, 프로필 이미지는 별도로 설정되지 않은 경우 `null`일 수 있습니다. 이미지가 `null`인 경우 프론트엔드 측의 기본 이미지가 사용됩니다.

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/ab0b031d-d9fc-4d4f-b700-6fd65fbe147a)

