### PR TITLE
액세스 토큰 유효성 검증 API 작성 완료

### DIFF
--- a/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
+++ b/src/main/java/com/munecting/api/domain/user/controller/AuthController.java
@@ -5,10 +5,9 @@ import com.munecting.api.domain.user.dto.request.LogoutRequestDto;
 import com.munecting.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.munecting.api.domain.user.dto.request.LoginRequestDto;
 import com.munecting.api.domain.user.dto.response.UserTokenResponseDto;
+import com.munecting.api.domain.user.dto.response.ValidateTokenResponseDto;
 import com.munecting.api.domain.user.service.AuthService;
-import com.munecting.api.global.auth.user.UserId;
 import com.munecting.api.global.common.dto.response.ApiResponse;
-import com.munecting.api.global.common.dto.response.Status;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,7 +55,6 @@ public class AuthController {
         return ApiResponse.ok(null);
     }
 
-
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급하기")
     public ApiResponse<?> refreshToken(
@@ -65,4 +63,15 @@ public class AuthController {
         UserTokenResponseDto dto = authService.refreshToken(refreshTokenRequestDto);
         return ApiResponse.created(dto);
     }
+
+    @GetMapping("/validate")
+    @Operation(summary = "액세스 토큰 유효성 검증")
+    public ApiResponse<?> validateAccessToken(
+            @Parameter(hidden = true)
+            @RequestHeader("Authorization") String authorizationHeaderValue
+    ){
+        ValidateTokenResponseDto dto = authService.validateAccessToken(authorizationHeaderValue);
+        return ApiResponse.ok(dto);
+    }
+
 }

--- a/src/main/java/com/munecting/api/domain/user/dto/response/ValidateTokenResponseDto.java
+++ b/src/main/java/com/munecting/api/domain/user/dto/response/ValidateTokenResponseDto.java
@@ -1,0 +1,16 @@
+package com.munecting.api.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ValidateTokenResponseDto(
+        boolean isValid
+) {
+
+    public static ValidateTokenResponseDto of(boolean isValid) {
+        return ValidateTokenResponseDto.builder()
+                .isValid(isValid)
+                .build();
+    }
+
+}

--- a/src/main/java/com/munecting/api/domain/user/service/AuthService.java
+++ b/src/main/java/com/munecting/api/domain/user/service/AuthService.java
@@ -7,6 +7,7 @@ import com.munecting.api.domain.user.dto.request.LogoutRequestDto;
 import com.munecting.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.munecting.api.domain.user.dto.request.LoginRequestDto;
 import com.munecting.api.domain.user.dto.response.UserTokenResponseDto;
+import com.munecting.api.domain.user.dto.response.ValidateTokenResponseDto;
 import com.munecting.api.domain.user.entity.User;
 import com.munecting.api.domain.user.dao.UserRepository;
 import com.munecting.api.global.auth.jwt.JwtProvider;
@@ -132,7 +133,7 @@ public class AuthService {
     }
 
     private Long getUserIdFromAccessToken(String requestToken) {
-        String token = jwtProvider.extractAccessToken(requestToken);
+        String token = extractAccessToken(requestToken);
 
         try {
             jwtProvider.validateTokenAtLogout(token);
@@ -154,4 +155,21 @@ public class AuthService {
             log.info("User {} logged out, no refresh token found", userId);
         }
     }
+
+    @Transactional(readOnly = true)
+    public ValidateTokenResponseDto validateAccessToken(String authorizationHeaderValue) {
+        try {
+            String accessToken = extractAccessToken(authorizationHeaderValue);
+            jwtProvider.validateAccessToken(accessToken);
+            return ValidateTokenResponseDto.of(true);
+        } catch (Exception e) {
+            log.info("Access token validation failed: {}", e.getMessage());
+            return ValidateTokenResponseDto.of(false);
+        }
+    }
+
+    private String extractAccessToken(String bearerToken) {
+        return jwtProvider.extractAccessToken(bearerToken);
+    }
+
 }

--- a/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/munecting/api/global/error/handler/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -73,15 +75,15 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 필수 쿼리 파라미터를 누락한 경우 발생하는 error를 handling 합니다.
+     * 필수 쿼리 파라미터 & 헤더를 누락한 경우 발생하는 error를 handling 합니다.
      */
-    @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ApiResponse<?>> handleMissingServletRequestParameterException(
-            MissingServletRequestParameterException e
+    @ExceptionHandler({MissingServletRequestParameterException.class, MissingRequestHeaderException.class})
+    public ResponseEntity<ApiResponse<?>> handleMissingRequestAttributes(
+            MissingRequestValueException e
     ) {
-        log.warn(">>> handle: MissingServletRequestParameterException", e);
+        log.warn(">>> handle: Missing required parameter or header Exception | [{}] - {}", e.getClass().getSimpleName(), e.getMessage());
 
-        ApiResponse<Object> response = ApiResponse.onFailure(BAD_REQUEST.toString(), e.getMessage(), null);
+        ApiResponse<Object> response = ApiResponse.onFailure(Status.BAD_REQUEST.getCode(), e.getMessage(), null);
         return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 

--- a/src/test/java/com/munecting/api/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/munecting/api/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,46 @@
+package com.munecting.api.domain.user.service;
+
+import com.munecting.api.domain.user.dto.response.ValidateTokenResponseDto;
+import com.munecting.api.global.auth.jwt.JwtProvider;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @DisplayName("주어진 액세스 토큰이 유효하면 true를 반환한다.")
+    @Test
+    public void validateAccessToken(){
+        //given
+        String accessToken = "Bearer " + jwtProvider.getIssueToken(1L, true);
+
+        //when
+        ValidateTokenResponseDto response = authService.validateAccessToken(accessToken);
+
+        //then
+        Assertions.assertThat(response.isValid()).isTrue();
+    }
+
+    @DisplayName("주어진 액세스 토큰이 유효하지 않으면 false를 반환한다.")
+    @Test
+    public void validateAccessToken_WithInValidToken(){
+        //given
+        String accessToken = "Bearer notVaild.아무값이나 넣었어.sdfhsodjf";
+
+        //when
+        ValidateTokenResponseDto response = authService.validateAccessToken(accessToken);
+
+        //then
+        Assertions.assertThat(response.isValid()).isFalse();
+    }
+
+}


### PR DESCRIPTION
## 📄 PR 요약
주어진 액세스 토큰을 검증한 후 유효한 값은 true, 유효하지 않은 값은 false를 반환합니다.

> 유효하지 않은 액세스 토큰 요청에 대한 응답 예시
> ```
> {
>   "isSuccess": true,
>   "code": "COMMON200",
>   "message": "성공입니다.",
>   "data": {
>     "isValid": false
>   }
> }
> ```

## 📋 관련 이슈
- close: #62

## 🛠️ 변경 사항 설명
`/api/auth/validate`는 화이트리스트에 등록되어 있는 경로로, 필터에서  Authorization 헤더 값을 검증하지 않습니다.
`/api/auth/validate` 컨트롤러 메서드에서 Authorization 헤더를 필수로 설정하여 바인딩 되는 값을 비즈니스 로직에서 사용하고 있습니다. 
필수 설정의 영향으로 다음 사진과 같이 Authorization 입력란이 중복 노출되어 혼동을 발생시키는 문제가 있었습니다.

1. 상단 Authorization 입력란 
    ![image](https://github.com/user-attachments/assets/bcf2431a-cc7b-45d9-a4ee-86907da9e289)
2. API 내부에 존재하는 Authorization 입력란 
    ![image](https://github.com/user-attachments/assets/55d021c0-a8b2-4bfb-8cf9-3f0f17e44cd3)
 
따라서 `@Parameter(hidden = true)`를 컨트롤러의 파라미터에 작성해주어 스웨거 화면에서  Authorization 입력란 중복 노출을 방지하였습니다.
    ![image](https://github.com/user-attachments/assets/b5ae1526-7b14-438e-b77c-37da87dd8cca)
