### PR TITLE
테스트 프로파일 활성화 

### DIFF
--- a/src/test/java/com/munecting/api/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/munecting/api/domain/user/service/AuthServiceTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AuthServiceTest {
 
     @Autowired


### PR DESCRIPTION
## 📄 PR 요약

테스트 프로파일을 활성화하지 않아 발생했던 github actions의 테스트 실패를 테스트 프로파일 활성화를 통해 해결하였습니다.

## 📋 관련 이슈

- close: #62